### PR TITLE
New SVG title slide for PyOHIO

### DIFF
--- a/dj/scripts/bling/pyohio.svg
+++ b/dj/scripts/bling/pyohio.svg
@@ -10,417 +10,26 @@
    xmlns:xlink="http://www.w3.org/1999/xlink"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   width="800"
-   height="600"
-   id="titlepage"
-   sodipodi:version="0.32"
-   inkscape:version="0.48.0 r9654"
-   version="1.0"
-   sodipodi:docname="pyohio.svg"
-   inkscape:output_extension="org.inkscape.output.svg.inkscape"
-   inkscape:export-filename="/home/carl/a/title2.png"
-   inkscape:export-xdpi="90"
-   inkscape:export-ydpi="90">
+   width="1052.3622"
+   height="744.09448"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.48+devel r10241 custom"
+   sodipodi:docname="pyohio.svg">
   <defs
      id="defs4">
-    <inkscape:perspective
-       sodipodi:type="inkscape:persp3d"
-       inkscape:vp_x="0 : 526.18109 : 1"
-       inkscape:vp_y="0 : 1000 : 0"
-       inkscape:vp_z="744.09448 : 526.18109 : 1"
-       inkscape:persp3d-origin="372.04724 : 350.78739 : 1"
-       id="perspective10" />
-    <inkscape:perspective
-       id="perspective2427"
-       inkscape:persp3d-origin="372.04724 : 350.78739 : 1"
-       inkscape:vp_z="744.09448 : 526.18109 : 1"
-       inkscape:vp_y="0 : 1000 : 0"
-       inkscape:vp_x="0 : 526.18109 : 1"
-       sodipodi:type="inkscape:persp3d" />
-    <inkscape:perspective
-       id="perspective2481"
-       inkscape:persp3d-origin="372.04724 : 350.78739 : 1"
-       inkscape:vp_z="744.09448 : 526.18109 : 1"
-       inkscape:vp_y="0 : 1000 : 0"
-       inkscape:vp_x="0 : 526.18109 : 1"
-       sodipodi:type="inkscape:persp3d" />
-    <inkscape:perspective
-       id="perspective2565"
-       inkscape:persp3d-origin="372.04724 : 350.78739 : 1"
-       inkscape:vp_z="744.09448 : 526.18109 : 1"
-       inkscape:vp_y="0 : 1000 : 0"
-       inkscape:vp_x="0 : 526.18109 : 1"
-       sodipodi:type="inkscape:persp3d" />
-    <inkscape:perspective
-       id="perspective2457"
-       inkscape:persp3d-origin="372.04724 : 350.78739 : 1"
-       inkscape:vp_z="744.09448 : 526.18109 : 1"
-       inkscape:vp_y="0 : 1000 : 0"
-       inkscape:vp_x="0 : 526.18109 : 1"
-       sodipodi:type="inkscape:persp3d" />
-    <inkscape:perspective
-       id="perspective2544"
-       inkscape:persp3d-origin="372.04724 : 350.78739 : 1"
-       inkscape:vp_z="744.09448 : 526.18109 : 1"
-       inkscape:vp_y="0 : 1000 : 0"
-       inkscape:vp_x="0 : 526.18109 : 1"
-       sodipodi:type="inkscape:persp3d" />
-    <inkscape:perspective
-       id="perspective2621"
-       inkscape:persp3d-origin="372.04724 : 350.78739 : 1"
-       inkscape:vp_z="744.09448 : 526.18109 : 1"
-       inkscape:vp_y="0 : 1000 : 0"
-       inkscape:vp_x="0 : 526.18109 : 1"
-       sodipodi:type="inkscape:persp3d" />
-    <inkscape:perspective
-       id="perspective2688"
-       inkscape:persp3d-origin="372.04724 : 350.78739 : 1"
-       inkscape:vp_z="744.09448 : 526.18109 : 1"
-       inkscape:vp_y="0 : 1000 : 0"
-       inkscape:vp_x="0 : 526.18109 : 1"
-       sodipodi:type="inkscape:persp3d" />
-    <inkscape:perspective
-       id="perspective2840"
-       inkscape:persp3d-origin="372.04724 : 350.78739 : 1"
-       inkscape:vp_z="744.09448 : 526.18109 : 1"
-       inkscape:vp_y="0 : 1000 : 0"
-       inkscape:vp_x="0 : 526.18109 : 1"
-       sodipodi:type="inkscape:persp3d" />
-    <inkscape:perspective
-       id="perspective2569"
-       inkscape:persp3d-origin="372.04724 : 350.78739 : 1"
-       inkscape:vp_z="744.09448 : 526.18109 : 1"
-       inkscape:vp_y="0 : 1000 : 0"
-       inkscape:vp_x="0 : 526.18109 : 1"
-       sodipodi:type="inkscape:persp3d" />
-    <inkscape:perspective
-       id="perspective2693"
-       inkscape:persp3d-origin="372.04724 : 350.78739 : 1"
-       inkscape:vp_z="744.09448 : 526.18109 : 1"
-       inkscape:vp_y="0 : 1000 : 0"
-       inkscape:vp_x="0 : 526.18109 : 1"
-       sodipodi:type="inkscape:persp3d" />
-    <inkscape:perspective
-       id="perspective2480"
-       inkscape:persp3d-origin="372.04724 : 350.78739 : 1"
-       inkscape:vp_z="744.09448 : 526.18109 : 1"
-       inkscape:vp_y="0 : 1000 : 0"
-       inkscape:vp_x="0 : 526.18109 : 1"
-       sodipodi:type="inkscape:persp3d" />
-    <inkscape:perspective
-       id="perspective2532"
-       inkscape:persp3d-origin="372.04724 : 350.78739 : 1"
-       inkscape:vp_z="744.09448 : 526.18109 : 1"
-       inkscape:vp_y="0 : 1000 : 0"
-       inkscape:vp_x="0 : 526.18109 : 1"
-       sodipodi:type="inkscape:persp3d" />
-    <inkscape:perspective
-       id="perspective2955"
-       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
-       inkscape:vp_z="1 : 0.5 : 1"
-       inkscape:vp_y="0 : 1000 : 0"
-       inkscape:vp_x="0 : 0.5 : 1"
-       sodipodi:type="inkscape:persp3d" />
-    <inkscape:perspective
-       id="perspective3008"
-       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
-       inkscape:vp_z="1 : 0.5 : 1"
-       inkscape:vp_y="0 : 1000 : 0"
-       inkscape:vp_x="0 : 0.5 : 1"
-       sodipodi:type="inkscape:persp3d" />
-    <inkscape:perspective
-       id="perspective3061"
-       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
-       inkscape:vp_z="1 : 0.5 : 1"
-       inkscape:vp_y="0 : 1000 : 0"
-       inkscape:vp_x="0 : 0.5 : 1"
-       sodipodi:type="inkscape:persp3d" />
-    <linearGradient
-       y2="1394.5615"
-       x2="-915.54724"
-       y1="1315.663"
-       x1="-915.54724"
-       gradientUnits="userSpaceOnUse"
-       id="linearGradient7077"
-       xlink:href="#linearGradient6128"
-       inkscape:collect="always" />
-    <linearGradient
-       y2="1394.5615"
-       x2="-915.54724"
-       y1="1315.663"
-       x1="-915.54724"
-       gradientUnits="userSpaceOnUse"
-       id="linearGradient7075"
-       xlink:href="#linearGradient6128"
-       inkscape:collect="always" />
-    <linearGradient
-       y2="1394.5615"
-       x2="-915.54724"
-       y1="1315.663"
-       x1="-915.54724"
-       gradientUnits="userSpaceOnUse"
-       id="linearGradient7073"
-       xlink:href="#linearGradient6128"
-       inkscape:collect="always" />
-    <linearGradient
-       y2="1394.5615"
-       x2="-915.54724"
-       y1="1315.663"
-       x1="-915.54724"
-       gradientUnits="userSpaceOnUse"
-       id="linearGradient7071"
-       xlink:href="#linearGradient6128"
-       inkscape:collect="always" />
-    <linearGradient
-       y2="1394.5615"
-       x2="-915.54724"
-       y1="1315.663"
-       x1="-915.54724"
-       gradientUnits="userSpaceOnUse"
-       id="linearGradient7069"
-       xlink:href="#linearGradient6128"
-       inkscape:collect="always" />
-    <linearGradient
-       y2="1394.5615"
-       x2="-915.54724"
-       y1="1315.663"
-       x1="-915.54724"
-       gradientUnits="userSpaceOnUse"
-       id="linearGradient7067"
-       xlink:href="#linearGradient6128"
-       inkscape:collect="always" />
-    <linearGradient
-       y2="1394.5615"
-       x2="-915.54724"
-       y1="1315.663"
-       x1="-915.54724"
-       gradientUnits="userSpaceOnUse"
-       id="linearGradient7065"
-       xlink:href="#linearGradient6128"
-       inkscape:collect="always" />
-    <linearGradient
-       y2="1394.5615"
-       x2="-915.54724"
-       y1="1315.663"
-       x1="-915.54724"
-       gradientUnits="userSpaceOnUse"
-       id="linearGradient7063"
-       xlink:href="#linearGradient6128"
-       inkscape:collect="always" />
-    <linearGradient
-       y2="1394.5615"
-       x2="-915.54724"
-       y1="1315.663"
-       x1="-915.54724"
-       gradientUnits="userSpaceOnUse"
-       id="linearGradient7061"
-       xlink:href="#linearGradient6128"
-       inkscape:collect="always" />
-    <linearGradient
-       y2="1394.5615"
-       x2="-915.54724"
-       y1="1315.663"
-       x1="-915.54724"
-       gradientUnits="userSpaceOnUse"
-       id="linearGradient7059"
-       xlink:href="#linearGradient6128"
-       inkscape:collect="always" />
-    <linearGradient
-       y2="1394.5615"
-       x2="-915.54724"
-       y1="1315.663"
-       x1="-915.54724"
-       gradientUnits="userSpaceOnUse"
-       id="linearGradient7057"
-       xlink:href="#linearGradient6128"
-       inkscape:collect="always" />
-    <linearGradient
-       y2="1394.5615"
-       x2="-915.54724"
-       y1="1315.663"
-       x1="-915.54724"
-       gradientUnits="userSpaceOnUse"
-       id="linearGradient7055"
-       xlink:href="#linearGradient6128"
-       inkscape:collect="always" />
-    <linearGradient
-       y2="1394.5615"
-       x2="-915.54724"
-       y1="1315.663"
-       x1="-915.54724"
-       gradientUnits="userSpaceOnUse"
-       id="linearGradient7053"
-       xlink:href="#linearGradient6128"
-       inkscape:collect="always" />
-    <linearGradient
-       y2="1394.5615"
-       x2="-915.54724"
-       y1="1315.663"
-       x1="-915.54724"
-       gradientUnits="userSpaceOnUse"
-       id="linearGradient7051"
-       xlink:href="#linearGradient6128"
-       inkscape:collect="always" />
-    <linearGradient
-       y2="1394.5615"
-       x2="-915.54724"
-       y1="1315.663"
-       x1="-915.54724"
-       gradientUnits="userSpaceOnUse"
-       id="linearGradient7049"
-       xlink:href="#linearGradient6128"
-       inkscape:collect="always" />
-    <linearGradient
-       y2="1394.5615"
-       x2="-915.54724"
-       y1="1315.663"
-       x1="-915.54724"
-       gradientUnits="userSpaceOnUse"
-       id="linearGradient7047"
-       xlink:href="#linearGradient6128"
-       inkscape:collect="always" />
-    <linearGradient
-       y2="1394.5615"
-       x2="-915.54724"
-       y1="1315.663"
-       x1="-915.54724"
-       gradientUnits="userSpaceOnUse"
-       id="linearGradient7045"
-       xlink:href="#linearGradient6128"
-       inkscape:collect="always" />
-    <linearGradient
-       y2="1394.5615"
-       x2="-915.54724"
-       y1="1315.663"
-       x1="-915.54724"
-       gradientUnits="userSpaceOnUse"
-       id="linearGradient7043"
-       xlink:href="#linearGradient6128"
-       inkscape:collect="always" />
-    <linearGradient
-       y2="1394.5615"
-       x2="-915.54724"
-       y1="1315.663"
-       x1="-915.54724"
-       gradientUnits="userSpaceOnUse"
-       id="linearGradient7041"
-       xlink:href="#linearGradient6128"
-       inkscape:collect="always" />
-    <linearGradient
-       y2="1394.5615"
-       x2="-915.54724"
-       y1="1315.663"
-       x1="-915.54724"
-       gradientUnits="userSpaceOnUse"
-       id="linearGradient7039"
-       xlink:href="#linearGradient6128"
-       inkscape:collect="always" />
-    <linearGradient
-       id="linearGradient6128"
-       inkscape:collect="always">
-      <stop
-         id="stop6130"
-         offset="0"
-         style="stop-color:#ffffff;stop-opacity:1;" />
-      <stop
-         id="stop6132"
-         offset="1"
-         style="stop-color:#ffffff;stop-opacity:0;" />
-    </linearGradient>
-    <linearGradient
-       y2="1394.5615"
-       x2="-915.54724"
-       y1="1315.663"
-       x1="-915.54724"
-       gradientUnits="userSpaceOnUse"
-       id="linearGradient7079"
-       xlink:href="#linearGradient6128"
-       inkscape:collect="always" />
-    <linearGradient
-       y2="-77.832855"
-       x2="-745.33875"
-       y1="-189.86911"
-       x1="-745.33875"
-       gradientTransform="matrix(0.98110573,0,0,1.0126928,-183.15151,1350.013)"
-       gradientUnits="userSpaceOnUse"
-       id="linearGradient7035"
-       xlink:href="#linearGradient4766"
-       inkscape:collect="always" />
-    <linearGradient
-       y2="-77.832855"
-       x2="-745.33875"
-       y1="-189.86911"
-       x1="-745.33875"
-       gradientTransform="matrix(0.9811715,0,0,1.0126918,-183.21014,1350.013)"
-       gradientUnits="userSpaceOnUse"
-       id="linearGradient7033"
-       xlink:href="#linearGradient4766"
-       inkscape:collect="always" />
-    <linearGradient
-       y2="-77.832855"
-       x2="-745.33875"
-       y1="-189.86911"
-       x1="-745.33875"
-       gradientTransform="matrix(0.98194585,0,0,0.97983226,-182.62577,1346.3901)"
-       gradientUnits="userSpaceOnUse"
-       id="linearGradient7031"
-       xlink:href="#linearGradient4766"
-       inkscape:collect="always" />
-    <linearGradient
-       y2="-77.832855"
-       x2="-745.33875"
-       y1="-189.86911"
-       x1="-745.33875"
-       gradientTransform="matrix(0.98182794,0,0,0.97983423,-182.72174,1346.3902)"
-       gradientUnits="userSpaceOnUse"
-       id="linearGradient7029"
-       xlink:href="#linearGradient4766"
-       inkscape:collect="always" />
-    <linearGradient
-       id="linearGradient4766"
-       inkscape:collect="always">
-      <stop
-         id="stop4768"
-         offset="0"
-         style="stop-color:#ff9955;stop-opacity:1" />
-      <stop
-         id="stop4770"
-         offset="1"
-         style="stop-color:#ff6600;stop-opacity:1" />
-    </linearGradient>
-    <linearGradient
-       y2="-77.832855"
-       x2="-745.33875"
-       y1="-189.86911"
-       x1="-745.33875"
-       gradientTransform="matrix(0.98178945,0,0,0.98178945,-182.75867,1346.4001)"
-       gradientUnits="userSpaceOnUse"
-       id="linearGradient7037"
-       xlink:href="#linearGradient4766"
-       inkscape:collect="always" />
     <linearGradient
        inkscape:collect="always"
-       id="linearGradient4940">
+       id="linearGradient3995">
       <stop
-         style="stop-color:#ffccaa;stop-opacity:1"
+         style="stop-color:#000000;stop-opacity:1;"
          offset="0"
-         id="stop4942" />
+         id="stop3997" />
       <stop
-         style="stop-color:#ff6600;stop-opacity:1"
+         style="stop-color:#000000;stop-opacity:0;"
          offset="1"
-         id="stop4944" />
+         id="stop3999" />
     </linearGradient>
-    <radialGradient
-       r="90.157059"
-       fy="-208.61775"
-       fx="-411.323"
-       cy="-208.61775"
-       cx="-411.323"
-       gradientTransform="matrix(-0.02228917,1.4933764,-0.93526017,-0.01395909,-788.90749,1779.2418)"
-       gradientUnits="userSpaceOnUse"
-       id="radialGradient6379"
-       xlink:href="#linearGradient4940"
-       inkscape:collect="always" />
     <linearGradient
        y2="-177.24957"
        x2="-702.27167"
@@ -428,67 +37,7 @@
        x1="-702.27167"
        gradientTransform="matrix(1.0390466,0,0,1.0390466,-186.33078,1310.5916)"
        gradientUnits="userSpaceOnUse"
-       id="linearGradient7025"
-       xlink:href="#linearGradient4805"
-       inkscape:collect="always" />
-    <linearGradient
-       y2="-177.24957"
-       x2="-702.27167"
-       y1="-287.68533"
-       x1="-702.27167"
-       gradientTransform="matrix(1.0390466,0,0,1.0390466,-186.33078,1310.5916)"
-       gradientUnits="userSpaceOnUse"
-       id="linearGradient7023"
-       xlink:href="#linearGradient4805"
-       inkscape:collect="always" />
-    <linearGradient
-       y2="-177.24957"
-       x2="-702.27167"
-       y1="-287.68533"
-       x1="-702.27167"
-       gradientTransform="matrix(1.0390466,0,0,1.0390466,-186.33078,1310.5916)"
-       gradientUnits="userSpaceOnUse"
-       id="linearGradient7021"
-       xlink:href="#linearGradient4805"
-       inkscape:collect="always" />
-    <linearGradient
-       y2="-177.24957"
-       x2="-702.27167"
-       y1="-287.68533"
-       x1="-702.27167"
-       gradientTransform="matrix(1.0390466,0,0,1.0390466,-186.33078,1310.5916)"
-       gradientUnits="userSpaceOnUse"
-       id="linearGradient7019"
-       xlink:href="#linearGradient4805"
-       inkscape:collect="always" />
-    <linearGradient
-       y2="-177.24957"
-       x2="-702.27167"
-       y1="-287.68533"
-       x1="-702.27167"
-       gradientTransform="matrix(1.0390466,0,0,1.0390466,-186.33078,1310.5916)"
-       gradientUnits="userSpaceOnUse"
-       id="linearGradient7017"
-       xlink:href="#linearGradient4805"
-       inkscape:collect="always" />
-    <linearGradient
-       y2="-177.24957"
-       x2="-702.27167"
-       y1="-287.68533"
-       x1="-702.27167"
-       gradientTransform="matrix(1.0390466,0,0,1.0390466,-186.33078,1310.5916)"
-       gradientUnits="userSpaceOnUse"
-       id="linearGradient7015"
-       xlink:href="#linearGradient4805"
-       inkscape:collect="always" />
-    <linearGradient
-       y2="-177.24957"
-       x2="-702.27167"
-       y1="-287.68533"
-       x1="-702.27167"
-       gradientTransform="matrix(1.0390466,0,0,1.0390466,-186.33078,1310.5916)"
-       gradientUnits="userSpaceOnUse"
-       id="linearGradient7013"
+       id="linearGradient7027"
        xlink:href="#linearGradient4805"
        inkscape:collect="always" />
     <linearGradient
@@ -504,37 +53,209 @@
          style="stop-color:#ffffff;stop-opacity:0;" />
     </linearGradient>
     <linearGradient
-       y2="-177.24957"
-       x2="-702.27167"
-       y1="-287.68533"
-       x1="-702.27167"
-       gradientTransform="matrix(1.0390466,0,0,1.0390466,-186.33078,1310.5916)"
+       y2="-77.832855"
+       x2="-745.33875"
+       y1="-189.86911"
+       x1="-745.33875"
+       gradientTransform="matrix(0.98178945,0,0,0.98178945,-182.75867,1346.4001)"
        gradientUnits="userSpaceOnUse"
-       id="linearGradient7027"
-       xlink:href="#linearGradient4805"
+       id="linearGradient7037"
+       xlink:href="#linearGradient4766"
        inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient4766"
+       inkscape:collect="always">
+      <stop
+         id="stop4768"
+         offset="0"
+         style="stop-color:#ff9955;stop-opacity:1" />
+      <stop
+         id="stop4770"
+         offset="1"
+         style="stop-color:#ff6600;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4940">
+      <stop
+         style="stop-color:#ffccaa;stop-opacity:1"
+         offset="0"
+         id="stop4942" />
+      <stop
+         style="stop-color:#ff6600;stop-opacity:1"
+         offset="1"
+         id="stop4944" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4805"
+       id="linearGradient4025"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0390466,0,0,1.0390466,-186.33078,1310.5916)"
+       x1="-702.27167"
+       y1="-287.68533"
+       x2="-702.27167"
+       y2="-177.24957" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4805"
+       id="linearGradient4027"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0390466,0,0,1.0390466,-186.33078,1310.5916)"
+       x1="-702.27167"
+       y1="-287.68533"
+       x2="-702.27167"
+       y2="-177.24957" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4805"
+       id="linearGradient4029"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0390466,0,0,1.0390466,-186.33078,1310.5916)"
+       x1="-702.27167"
+       y1="-287.68533"
+       x2="-702.27167"
+       y2="-177.24957" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4805"
+       id="linearGradient4031"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0390466,0,0,1.0390466,-186.33078,1310.5916)"
+       x1="-702.27167"
+       y1="-287.68533"
+       x2="-702.27167"
+       y2="-177.24957" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4805"
+       id="linearGradient4033"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0390466,0,0,1.0390466,-186.33078,1310.5916)"
+       x1="-702.27167"
+       y1="-287.68533"
+       x2="-702.27167"
+       y2="-177.24957" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4805"
+       id="linearGradient4035"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0390466,0,0,1.0390466,-186.33078,1310.5916)"
+       x1="-702.27167"
+       y1="-287.68533"
+       x2="-702.27167"
+       y2="-177.24957" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4805"
+       id="linearGradient4037"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0390466,0,0,1.0390466,-186.33078,1310.5916)"
+       x1="-702.27167"
+       y1="-287.68533"
+       x2="-702.27167"
+       y2="-177.24957" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4805"
+       id="linearGradient4039"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0390466,0,0,1.0390466,-186.33078,1310.5916)"
+       x1="-702.27167"
+       y1="-287.68533"
+       x2="-702.27167"
+       y2="-177.24957" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4766"
+       id="linearGradient4041"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.98182794,0,0,0.97983423,-182.72174,1346.3902)"
+       x1="-745.33875"
+       y1="-189.86911"
+       x2="-745.33875"
+       y2="-77.832855" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4766"
+       id="linearGradient4043"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.98194585,0,0,0.97983226,-182.62577,1346.3901)"
+       x1="-745.33875"
+       y1="-189.86911"
+       x2="-745.33875"
+       y2="-77.832855" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4766"
+       id="linearGradient4045"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9811715,0,0,1.0126918,-183.21014,1350.013)"
+       x1="-745.33875"
+       y1="-189.86911"
+       x2="-745.33875"
+       y2="-77.832855" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4766"
+       id="linearGradient4047"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.98110573,0,0,1.0126928,-183.15151,1350.013)"
+       x1="-745.33875"
+       y1="-189.86911"
+       x2="-745.33875"
+       y2="-77.832855" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4766"
+       id="linearGradient4049"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.98178945,0,0,0.98178945,-182.75867,1346.4001)"
+       x1="-745.33875"
+       y1="-189.86911"
+       x2="-745.33875"
+       y2="-77.832855" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4940"
+       id="radialGradient4051"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.02228917,1.4933764,-0.93526017,-0.01395909,-788.90749,1779.2418)"
+       cx="-411.323"
+       cy="-208.61775"
+       fx="-411.323"
+       fy="-208.61775"
+       r="90.157059" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3995"
+       id="linearGradient4072"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.43712436,0,0,0.56187799,1108.794,179.44726)"
+       x1="-1278.4458"
+       y1="1277.2576"
+       x2="-1278.4458"
+       y2="963.19293" />
   </defs>
   <sodipodi:namedview
      id="base"
-     pagecolor="#6b050e"
+     pagecolor="#ffffff"
      bordercolor="#666666"
      borderopacity="1.0"
-     gridtolerance="10000"
-     guidetolerance="10"
-     objecttolerance="10"
-     inkscape:pageopacity="1"
+     inkscape:pageopacity="0.0"
      inkscape:pageshadow="2"
-     inkscape:zoom="0.84880128"
-     inkscape:cx="400.82123"
-     inkscape:cy="300.3454"
+     inkscape:zoom="0.89346309"
+     inkscape:cx="652.02912"
+     inkscape:cy="339.05599"
      inkscape:document-units="px"
      inkscape:current-layer="layer1"
      showgrid="false"
-     inkscape:window-width="1267"
-     inkscape:window-height="721"
-     inkscape:window-x="61"
-     inkscape:window-y="30"
-     inkscape:window-maximized="0" />
+     inkscape:window-width="1680"
+     inkscape:window-height="971"
+     inkscape:window-x="0"
+     inkscape:window-y="27"
+     inkscape:window-maximized="1" />
   <metadata
      id="metadata7">
     <rdf:RDF>
@@ -543,452 +264,693 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
+        <dc:title></dc:title>
       </cc:Work>
     </rdf:RDF>
   </metadata>
   <g
      inkscape:label="Layer 1"
      inkscape:groupmode="layer"
-     id="layer1">
-    <rect
-       style="opacity:1;fill:#000000;fill-opacity:0"
-       id="rect2398"
-       width="800"
-       height="600"
-       x="0"
-       y="0" />
+     id="layer1"
+     transform="translate(0,-308.2677)">
+    <path
+       inkscape:connector-curvature="0"
+       id="path3573"
+       d="m 127.363,681.18152 0,-300.00002 400.00001,0 399.99999,0 0,300.00002 0,299.99998 -399.99999,0 -400.00001,0 0,-299.99998 z"
+       style="fill:#8e0506"
+       inkscape:export-filename="/home/cats/Desktop/pyohio.png"
+       inkscape:export-xdpi="71.95591"
+       inkscape:export-ydpi="71.95591" />
+    <path
+       style="fill:#700505;opacity:0.75"
+       d="m 164.10396,957.72081 c -11.2278,-12.73769 1.00883,-33.24758 6.86997,-10.06625 19.2239,-12.16637 -9.80877,-28.23779 -4.67932,-29.68008 27.50543,-19.9013 -22.05651,-36.65258 -8.9242,-64.40313 7.69146,-41.04503 -0.0545,-82.12524 0.86139,-123.45625 -0.355,-38.14104 0.27632,-76.28131 0.34244,-114.4221 12.68215,13.70968 28.3818,-18.13458 6.75364,-12.33345 -17.24069,-38.87428 -1.54406,-81.94645 -7.10349,-122.65205 0,-26.03846 0,-52.07692 0,-78.11538 153.43969,0.48791 306.89249,-1.12153 460.32073,1.43327 14.29072,29.6846 4.85607,53.30011 1.69031,82.52643 -12.21323,0.81454 2.30622,7.9228 -11.20719,6.3015 -13.20307,14.17686 7.26938,1.19922 -0.29204,20.18468 -7.31919,16.03102 8.55605,24.23321 8.92431,5.07966 17.70337,1.84631 2.69166,24.04213 -1.4309,18.21766 -9.8682,22.11612 22.3161,-0.13149 4.62371,22.91927 -11.70305,15.17605 -18.56306,14.1888 -0.51579,5.20618 14.26003,10.1861 -7.75595,17.75675 5.19115,27.32815 -5.06681,25.81166 19.89622,16.63123 29.26395,14.53123 9.87859,17.74972 -39.6517,29.93123 -1.61725,21.68251 7.47419,7.91076 2.44255,55.50956 15.98262,20.78129 15.52208,-29.43349 -15.68576,-91.84665 24.63451,-99.92754 12.69277,4.19267 44.6458,3.00752 14.16115,-2.63295 -18.21961,4.81722 -50.93757,-23.77248 -15.54448,-18.79152 20.05935,3.47749 26.4934,-9.21982 2.59123,-7.96443 -34.1435,-8.25373 -5.11695,-22.68645 13.07441,-21.08639 -10.02209,-4.77071 -47.5259,-12.81374 -20.46326,-22.81077 15.16641,-1.52178 74.03197,5.44649 41.96778,24.33283 -32.04912,-0.50171 31.37214,4.77671 8.48355,24.54749 -4.48317,-1.40077 5.02498,47.74132 7.89054,17.04209 3.76027,-23.6669 -10.66388,-54.35424 6.2825,-73.31967 0.34974,24.81455 11.10453,0.70144 3.13826,-8.58485 4.90858,-27.07519 61.95021,-28.05411 26.32408,0.3564 -14.46864,11.85444 28.69391,-9.70653 10.03712,15.28924 -11.77876,15.27192 19.27149,20.21321 -3.51524,34.77856 -29.75579,15.29684 11.72188,-5.79594 9.04892,20.27549 0.74307,35.80669 -0.77327,71.95615 6.51606,107.2974 16.64288,2.87238 19.49637,-48.26835 14.0153,-63.91099 17.01012,-31.41325 71.30214,29.39301 66.82905,-19.3073 -13.24558,-35.70931 17.32987,-94.50127 -17.0152,-115.71142 -32.91441,-18.81559 -73.22129,-21.62842 -102.08862,3.78614 6.81035,-15.40851 42.82331,-25.55484 10.05286,-31.44077 -21.83548,-18.49764 33.97487,-5.37532 44.27129,-1.4956 16.80101,0.4016 23.24219,-6.17592 17.49935,7.38466 30.85493,3.90923 72.231,16.59129 57.16477,57.00173 -1.57304,61.692 0.8473,123.61729 -0.0173,185.44866 0.0338,99.56357 -0.10169,199.12713 -0.0235,298.69069 -136.87991,-0.14861 -273.7614,0.38805 -410.63991,-0.45635 -7.33557,-10.88 -43.80833,-38.59815 -13.54927,-41.05119 0.13271,37.26669 64.44548,20.11103 38.64746,-13.65707 -8.67397,-16.28819 -29.95827,-19.0438 -1.25624,-24.90516 25.13583,-23.18794 -33.77951,-32.61769 -50.5178,-39.10762 -14.72455,-3.39256 -73.15972,-2.02992 -35.83528,-21.56164 13.21933,-4.90025 15.46728,-18.12106 12.87962,1.13486 21.73577,22.69282 38.14948,-14.12981 26.06399,-33.04984 -0.90907,-19.64836 10.1329,-66.30882 -23.08046,-49.1323 -32.91625,-5.28189 -64.87525,7.08601 -98.16081,0.75839 -52.36156,-2.71338 -4.30589,67.20358 -45.63326,78.88596 -10.60925,-10.68971 -15.85763,-10.87187 -28.74458,-4.82552 20.49792,-22.89883 -18.06281,-53.09511 -22.78244,-17.24384 15.4696,28.4 9.72789,67.14759 16.56537,96.84347 -19.47977,18.5129 4.48686,64.29875 -23.12382,66.23634 -23.92713,-1.94572 -47.32437,0.0268 -71.20174,0.82119 z m 76.19082,-3.30586 c -0.59241,-2.97793 -0.85133,3.28026 0,0 z m -60.33161,-2.16164 c 12.7678,-9.57924 -6.23177,-2.04109 0,0 z m -8.85803,-1.38053 c -0.3115,-4.35778 -3.28827,2.41028 0,0 z m 67.89324,-4.08124 c 2.5063,-6.70597 -5.77674,4.27399 0,0 z m 4.7966,-4.4897 c -2.40032,-2.39599 0.87947,6.65561 0,0 z m -52.44303,-2.29505 c -0.40169,-2.41214 -1.53498,1.43601 0,0 z m 0.30139,-2.8338 c -0.91704,-6.10672 -2.93304,6.00448 0,0 z m 4.30016,0.33438 c -0.2474,-3.27357 -1.72417,2.20502 0,0 z m 315.66603,-0.86581 c -1.77103,-6.57958 -4.68233,3.95595 0,0 z m -317.04645,-0.83322 c -1.02173,-2.45274 -1.02149,2.4528 0,0 z m -1.54155,-2.22168 c 21.82434,-7.285 59.78169,-45.27338 46.67972,-60.36005 -25.01452,6.92544 -47.95062,41.96382 -46.67972,60.36005 z m 19.48754,-36.10238 c 1.02149,-2.45279 1.02171,2.45275 0,0 z m 7.59257,-8.33137 c 0.83333,-2.42054 0.72255,2.19716 0,0 z m 12.19405,-6.64764 1.36529,0.30947 -1.36529,-0.30947 z m 11.96402,-9.45956 c 1.02171,-2.45275 1.02149,2.45279 0,0 z m 291.63567,61.34259 c 3.69281,-7.30048 -6.58918,3.54191 0,0 z M 240.32,932.11863 c 0.33,-3.66094 -1.8154,3.9227 0,0 z m 278.432,-0.19818 c -0.0483,-4.5156 -3.4924,3.87788 0,0 z m -275.83194,-3.92423 c 3.3592,-6.89091 -5.81167,6.63146 0,0 z m -50.6478,0.0361 c -1.0215,-2.45297 -1.0218,2.45295 0,0 z m -21.16712,-4.99885 c -1.79493,-7.94013 -1.75002,5.59084 0,0 z m 6.9116,-4.17905 c -0.28902,-4.33664 -3.33552,5.55805 0,0 z m -7.94696,-2.0694 c -1.74213,-3.43446 -1.74239,3.43446 0,0 z m 82.02261,-1.21691 c -0.4015,-2.41215 -1.53501,1.43584 0,0 z m -84.89851,-1.42139 c -1.28025,-2.7673 -1.23613,2.56091 0,0 z m 11.04364,-0.55537 c -1.05997,-2.87102 -0.98022,2.40177 0,0 z m 337.89604,-2.63829 c -1.64195,-3.55696 -1.07777,3.93377 0,0 z m -0.47969,-10.333 c -2.26495,-16.00168 -12.77524,-3.32328 0,0 z m -5.14654,0.82639 -2.15913,0.23544 2.15913,-0.23544 z m -2.82948,-5.32909 c -5.03896,-1.70501 5.69247,8.94034 0,0 z m -3.08778,-5.3093 c -1.74082,-5.43324 -1.08785,4.29626 0,0 z m 2.07388,-1.05616 c -3.40699,-5.82883 1.69931,5.22381 0,0 z m -8.21287,-1.22588 c 10.21272,-11.05812 -7.79745,1.35103 0,0 z m -6.15797,-2.11759 c -0.24702,-3.27346 -1.72442,2.20465 0,0 z m 2.30074,-1.14366 c -1.0218,-2.45292 -1.02149,2.45299 0,0 z m 31.46174,-10.84906 c 17.21231,-10.10899 -7.79241,-2.05808 0,0 z m -2.93214,-4.36558 c -1.61972,-3.46033 -2.05664,1.69416 0,0 z m 1.38042,-0.64761 c -1.72435,-2.20505 -0.2472,3.27377 0,0 z m -284.14541,-3.0221 c -3.0404,-0.95146 1.26346,3.66625 0,0 z m 278.14233,-0.0474 c -1.93192,-3.8727 0.70827,3.88841 0,0 z m 10.37538,-0.50935 c 16.08399,3.97014 -3.70978,-9.1667 0,0 z m -2.53168,-0.89645 c -1.44673,-6.35235 -4.57865,2.76234 0,0 z m 0,-2.99002 c -0.72254,-2.19717 -0.83333,2.42054 0,0 z m 2.76093,-1.35576 c -0.40168,-2.41215 -1.53498,1.43598 0,0 z m 2.83495,-1.28253 c 15.13712,-12.85232 -11.65212,-8.91344 0,0 z m -47.93004,-9.27055 c -0.40179,-2.41193 -1.53487,1.43591 0,0 z m -16.10546,-8.36408 c -1.18393,-3.02514 -0.83293,3.4397 0,0 z m 8.74299,-0.27764 c -1.0215,-2.45278 -1.02172,2.45275 0,0 z m 46.28823,-0.98053 c 7.14143,-11.02014 -7.99027,-3.94169 0,0 z m 8.00995,-1.24115 c -0.72253,-2.1972 -0.83335,2.42051 0,0 z m -294.0388,-8.08645 c -1.72436,-2.20505 -0.24721,3.27377 0,0 z m 5.52185,-6.10959 c -1.18378,-10.18962 -0.93891,12.28898 0,0 z m -82.15723,-12.98128 c -0.57546,-3.20946 -1.82529,3.13402 0,0 z m 142.21866,-3.4323 c 1.15119,-11.28485 -3.78465,4.71053 0,0 z m -142.88921,-2.71568 c -1.02148,-2.4528 -1.02172,2.45272 0,0 z m 53.11016,-8.11308 c 3.71723,-5.59535 -6.33208,0.93869 0,0 z m -9.86271,-5.35593 c -2.91041,-0.63896 1.63495,4.23964 0,0 z m 267.81703,-5.97082 c 21.44563,-4.28236 -16.87813,-12.8815 0,0 z m 3.07531,-0.1041 -0.0846,1.00342 0.0846,-1.00342 z m 22.0453,-1.3827 c 6.79991,-14.7125 -10.20419,0.27247 0,0 z m -8.77462,-0.39844 c 16.22397,-12.63943 -9.83,-9.36979 0,0 z m 26.49273,-0.47264 -1.87452,-0.45966 1.87452,0.45966 z m -7.40675,1.00211 c -0.40178,-2.41195 -1.53487,1.4359 0,0 z m 25.30847,-2.13554 c 1.01043,-15.00656 -8.29032,3.5502 0,0 z m -67.28278,0.8001 c -2.34434,-2.82616 -1.13305,4.14625 0,0 z m 41.62916,-0.85902 c 4.19746,-12.69472 -8.94073,-0.62186 0,0 z m 16.91064,-1.11279 c 1.32222,-6.38148 -5.90153,5.85295 0,0 z m -9.2031,-1.66044 c -1.35843,-10.43397 -4.96375,4.76878 0,0 z m -298.44307,-3.99149 c 5.91759,-20.16471 -16.36313,3.52926 0,0 z m 26.93746,-10.02875 c -5.47142,-10.18309 -3.7432,8.69943 0,0 z m 359.03743,0.39081 c 15.41089,-13.35264 -12.053,-79.0598 -15.00848,-37.01259 5.76278,22.54038 -22.24181,27.71654 -27.61621,6.2441 -19.89894,40.2552 25.98465,16.05719 42.62469,30.76849 z m -27.2726,-10.64283 c -0.66212,-5.39186 3.13943,4.44424 0,0 z m 9.22421,-0.75273 c 0.24698,-3.27366 1.72455,2.20468 0,0 z m 10.46847,-31.31215 c -2.87205,-5.98491 15.23676,5.28815 0,0 z m -378.28941,33.15045 c 4.4725,-19.15093 -17.26478,4.80366 0,0 z m 41.34119,-0.15806 c 17.75634,10.98706 44.68937,-36.371 16.18553,-15.40651 -11.83447,-1.21142 -25.63759,-0.0139 -16.18553,15.40651 z m 8.54845,-8.47283 c -4.23449,-7.94804 6.72241,1.59117 0,0 z m -4.12093,-0.37916 c -20.02523,6.66583 7.24661,-11.04198 0,0 z m 20.19074,-2.05836 c 1.53502,-1.43582 0.40148,2.41216 0,0 z m 0.4602,-5.52142 c 1.0218,-2.45292 1.02149,2.45299 0,0 z m 4.60155,-4.99874 c -0.87232,-2.23085 3.05697,2.15834 0,0 z m 255.3858,19.42002 c -2.19356,-9.88996 -6.31473,4.67274 0,0 z m -300.75449,0.30001 c 12.14749,-24.42778 -15.09979,0.20842 0,0 z m 55.80639,-7.60495 -0.0846,1.00355 0.0846,-1.00355 z m 246.78873,-6.89802 c -2.08377,-3.0784 -0.62171,4.70313 0,0 z m -266.43876,-2.73116 c -1.9285,-3.40305 0.23418,2.7177 0,0 z m -62.29317,-0.13391 c 6.95351,-18.74724 -17.58287,2.01242 0,0 z m 41.54027,-3.6017 c 30.5809,-21.21085 -29.81533,-10.45243 0,0 z m 34.10658,-0.97198 c -1.48483,-2.81346 -1.48495,2.81347 0,0 z m 10.12341,-3.33254 c -1.23613,-2.56091 -1.28025,2.76731 0,0 z m 208.51941,-0.4166 c 3.90854,-13.83241 -13.37699,-1.00264 0,0 z M 362.26132,726.4304 c -0.59056,-32.81463 -11.6165,15.6014 0,0 z m 66.44453,2.43917 c 10.76867,-18.24234 -15.50235,-8.42156 0,0 z m 102.24019,-3.01074 c -0.83335,-2.42051 -0.72252,2.19721 0,0 z m -90.19026,-1.66621 c -0.83296,-2.42078 -0.72298,2.19712 0,0 z m 38.38667,-0.0361 c 7.69329,-8.5051 -11.45339,-0.77584 0,0 z m 48.12235,-0.45116 c 16.09564,-12.04788 -17.1019,-13.14441 0,0 z m -51.99746,-0.31808 c 0.65926,-7.96083 -6.43927,1.24205 0,0 z m -64.76673,-2.14916 c 37.62638,-38.15108 -58.66826,-57.90649 -41.2084,-8.43636 6.67007,8.49233 29.0205,1.23664 41.2084,8.43636 z m -3.256,-2.983 c 5.43796,-6.45813 5.84388,6.25143 0,0 z m -26.09698,-6.87242 c 1.50683,-6.26584 4.85322,4.56219 0,0 z m -10.33539,-23.88051 c 1.53488,-1.4359 0.40179,2.41195 0,0 z m 91.11066,35.58651 c 6.59041,-22.22376 -25.76675,-6.30652 0,0 z m 40.96655,-1.14643 c 5.52039,-11.00509 -7.94142,-2.46069 0,0 z m -115.51164,0.8947 c -0.40168,-2.41215 -1.53498,1.43599 0,0 z m 6.90237,-2.13626 c -2.72878,-4.57881 -3.0468,4.24621 0,0 z m 114.00327,-1.00631 c 6.4787,-12.58191 -9.74249,2.31196 0,0 z m 191.83442,-2.30557 c -6.94854,-14.39833 -6.11774,13.50655 0,0 z m -203.22321,0.24998 c 5.5354,-8.49099 -5.71098,1.9885 0,0 z m -59.36001,-3.99902 c -0.83296,-2.42077 -0.72298,2.19712 0,0 z m 32.67104,-1.94395 c -0.85938,-5.01918 -1.15945,5.00648 0,0 z m 21.16712,0.83311 -1.67804,0.40818 1.67804,-0.40818 z m 15.03301,-0.27773 c -2.37632,-3.71521 -2.8742,3.99766 0,0 z m -25.61661,-1.38859 c -0.72298,-2.19712 -0.83296,2.42078 0,0 z m 16.56557,0.31055 c -0.40167,-2.41216 -1.53499,1.43598 0,0 z m 31.62602,-0.0908 -0.84441,0.0313 0.84441,-0.0313 z M 276.77433,707.8077 c 16.06729,-25.61759 -5.90061,-58.4009 3.84225,-86.02129 -0.026,-16.82522 -13.35119,-28.28332 -11.91332,-3.96657 -3.87437,29.97289 -4.2816,61.79081 8.07107,89.98786 z m 3.84765,-25.85995 c 1.53499,-1.43598 0.40168,2.41217 0,0 z m -1.3805,-3.8551 c 0.83295,-2.42078 0.72297,2.19712 0,0 z m -5.29176,-19.43982 c 0.9803,-2.40167 1.0598,2.87126 0,0 z m -4.62044,-55.02353 1.08519,-0.64731 -1.08519,0.64731 z m 3.00991,-3.01786 c 1.99907,-4.05266 1.99919,4.05266 0,0 z m 13.7126,106.25214 c -0.70886,-14.02879 -11.41951,7.54525 0,0 z m 184.03338,-1.93868 c -3.08449,-3.6228 0.67063,3.52166 0,0 z m 154.04224,-0.0794 c -1.66313,-2.77416 -0.69015,3.58767 0,0 z M 491.5335,702.79116 c -1.79921,-2.60536 0.59569,4.12037 0,0 z m 137.72686,0.0413 c -2.0576,-3.61717 0.30307,4.0211 0,0 z m -175.16014,0.34625 c 0.2019,-4.32651 -2.2268,1.41618 0,0 z m 10.82286,-2.27936 c 14.40346,3.4504 54.28067,-9.26996 18.7423,-8.3915 -2.99222,2.36196 -25.03579,1.4993 -18.7423,8.3915 z m 31.79175,-4.24271 c -1.60615,-3.85133 2.97418,1.50005 0,0 z m 111.30712,5.31868 c -1.28012,-2.76708 -1.23602,2.56076 0,0 z m 9.8933,-0.55538 c -1.02149,-2.45297 -1.02178,2.45294 0,0 z m 6.90237,-0.34572 c -2.30437,-1.7612 0.0925,4.93982 0,0 z m -117.28003,-2.02635 c -3.17611,-0.56489 2.63531,3.31583 0,0 z M 458.3591,698.792 c 17.83755,-17.81217 -12.67768,-8.16395 0,0 z m -100.43119,-1.0151 c -1.72436,-2.20504 -0.2472,3.27377 0,0 z m 95.30099,-1.28118 c 10.6659,-11.45208 -5.12602,-2.29359 0,0 z m 160.93323,1.30818 c -3.02376,-4.34949 -4.86267,3.42615 0,0 z m -5.44997,-0.76264 c -2.04128,-6.93327 -4.24552,5.1334 0,0 z m -144.48853,-0.065 c -1.02179,-2.45294 -1.0215,2.45298 0,0 z m 43.71475,-0.83311 c -1.04197,-3.28287 -1.04196,3.28289 0,0 z m 116.87924,-0.8331 c -1.02149,-2.4528 -1.02172,2.45275 0,0 z m -140.0534,-1.94396 c 6.82663,-1.58815 -2.8361,-2.3948 0,0 z m 23.17416,0.38875 c 8.83019,-12.09074 -8.65745,-0.33764 0,0 z m -146.33624,-2.47155 c -2.60951,-2.46899 2.1322,7.39361 0,0 z m 116.88633,1.24962 c -1.02171,-2.45275 -1.02148,2.45278 0,0 z m 2.94898,-1.52745 c -2.69979,-5.73526 -0.70272,10.31874 0,0 z m 128.50829,1.05533 c 5.44959,-17.98383 -13.12887,-2.43957 0,0 z m -133.45063,-2.53956 -1.63352,0.98228 1.63352,-0.98228 z m -5.82932,0.2698 c 1.14012,-10.50561 -3.41755,5.18561 0,0 z m -29.4499,0.52018 -1.277,-0.40994 1.277,0.40994 z m 46.47568,-3.14228 c -2.13163,-17.3474 -6.49571,3.65045 0,0 z m 14.72496,0.45271 c -2.18209,-12.21359 -5.532,3.55809 0,0 z m 4.60155,0.41815 c -0.44951,-7.73618 -4.66328,0.50399 0,0 z m -42.44922,-0.91419 c -1.72049,-8.24744 -4.56104,5.33694 0,0 z m 8.85402,-0.13227 c -0.55677,-5.30939 -3.90201,4.67944 0,0 z m 4.26879,0.20656 c 3.88575,-11.55394 -5.34106,-1.25937 0,0 z m -8.86649,-0.49885 c -0.63668,-7.39971 -5.25936,2.63697 0,0 z m 12.22506,-1.81405 c -3.34921,-1.48523 -0.25742,3.08533 0,0 z m 123.89444,-0.65069 c -2.13524,-2.17651 -0.30896,3.81013 0,0 z m 19.58105,-1.71036 c -5.08966,-0.78791 2.1593,5.97352 0,0 z m 4.89344,2.01287 c 0.21323,-5.15466 -2.25595,1.89399 0,0 z m 105.69167,0.33726 c 10.54192,-17.24439 -12.78542,-11.64399 0,0 z m -366.13922,-2.06301 c -1.37343,-3.6029 -2.77667,4.59463 0,0 z m 245.72259,0.58818 c -0.40179,-2.41193 -1.53487,1.4359 0,0 z m -125.62222,-0.86592 c -0.72298,-2.19712 -0.83295,2.42079 0,0 z m 127.92296,-0.27763 c -1.1836,-3.02548 -0.83335,3.4396 0,0 z m 108.88005,0.50245 c 10.95184,-16.36294 -12.01283,-10.88992 0,0 z m -268.09354,-1.36837 c -1.72436,-2.20503 -0.24719,3.27378 0,0 z m 172.6694,-1.37361 c -3.46544,-0.98476 2.16981,4.29518 0,0 z m -6.50577,-0.42444 c -2.52817,-1.51722 0.92388,3.19787 0,0 z m 89.03541,-2.70649 c 0.47993,-15.27339 -8.0407,-0.0443 0,0 z m -75.27855,0.37161 c -1.82332,-4.10118 -2.00701,3.74713 0,0 z m 81.46532,-0.49832 c 0.16255,-8.10641 -2.19039,3.55307 0,0 z m -55.39551,-0.45313 c 4.81247,-9.34753 -5.59491,2.85095 0,0 z m -15.02609,-0.10007 -1.36537,-0.30947 1.36537,0.30947 z m 7.11811,-1.42015 c 0.21941,-6.91078 -4.08939,1.56567 0,0 z m -370.46417,-2.82616 c -1.1577,-7.75637 -6.25799,5.58115 0,0 z m 371.85887,0.0216 c -0.72253,-2.19721 -0.83335,2.42051 0,0 z m 6.74132,-2.49942 c -1.11114,-3.02306 -1.11115,3.02305 0,0 z m -5.13072,-0.27775 c -1.02173,-2.45272 -1.02148,2.4528 0,0 z m 2.21774,-1.01551 c -1.98215,-4.56151 -0.9149,5.56284 0,0 z m 47.49813,-1.45595 c -3.90889,-2.29352 2.79369,6.86186 0,0 z m 107.07029,0.80526 c -0.83145,-4.49495 -0.41862,3.48306 0,0 z m -157.24635,-0.55546 c -1.33064,-4.62887 -0.7964,4.01623 0,0 z m 164.53557,-1.37465 c 9.38205,-17.06478 -11.95194,-33.59205 -9.40618,-7.53116 1.77522,3.79625 5.59206,6.18975 9.40618,7.53116 z m -9.2219,-13.04393 c -1.42329,-2.83559 2.67374,0.38465 0,0 z m 6.31567,-5.76386 c -3.28793,-5.51212 8.9111,5.09805 0,0 z M 710.57276,665.5953 c -0.87916,-3.31865 -0.5558,2.98317 0,0 z m -81.96124,-1.66631 c -1.07038,-5.00718 -1.28215,5.24963 0,0 z m 28.27112,0.17353 -0.0847,1.00353 0.0847,-1.00353 z m 0.60593,-1.56211 c -1.02179,-2.45293 -1.02149,2.45297 0,0 z M 282.6303,657.81507 c 12.43712,-0.81339 -6.76626,-3.99453 0,0 z m 127.37977,0.28196 c 31.071,-14.50131 -22.17244,-13.77858 0,0 z m -2.27039,-1.47864 c -2.73612,-3.99631 4.06586,0.82906 0,0 z m 52.80271,1.47864 c -1.28013,-2.76707 -1.23601,2.56077 0,0 z m -87.88953,-1.12828 c 1.00845,-9.34801 -9.04016,6.4282 0,0 z m 435.71666,-2.39202 c -5.14684,-4.27828 1.35145,8.30104 0,0 z m -432.49553,1.57635 c -0.85357,-4.50093 -1.55147,2.49823 0,0 z m 184.49221,-0.5987 c -2.8645,-2.48935 0.90801,3.91409 0,0 z m 74.51731,1.08474 c 14.4798,-5.10026 -5.75953,-5.57963 0,0 z m 175.60648,-0.76377 c -0.98022,-2.40175 -1.05996,2.87103 0,0 z m -407.31477,-2.27617 c 2.79413,-11.40369 -7.48282,-0.0355 0,0 z m 227.85447,1.16542 c -1.29983,-3.89484 -1.29983,3.89485 0,0 z m 8.8806,-0.37699 c -2.47803,-3.60239 -0.17505,5.00879 0,0 z m 4.70027,-0.59498 c 3.31141,-9.74658 -8.71387,3.10596 0,0 z m 151.60245,-0.87262 c 4.85915,-20.25189 -5.34235,5.21035 0,0 z m -146.44762,0.42856 c 1.0736,-7.7505 -6.99513,0.0859 0,0 z m 155.43284,-0.52802 c -1.04217,-3.28292 -1.0417,3.28313 0,0 z m 75.99457,0 c -1.11135,-3.02313 -1.11097,3.0233 0,0 z m -89.56912,-1.66622 c -2.84383,-6.94824 -2.16139,6.78196 0,0 z m -303.09318,0.0929 c -1.91013,-3.73952 -0.96369,4.59022 0,0 z m -109.43547,-0.0929 c -1.04198,-3.28304 -1.04196,3.28308 0,0 z m 503.82615,-0.6183 c -2.65665,-2.02602 1.25214,3.77717 0,0 z m -598.86969,0.25142 c 2.96606,-8.28262 -8.35065,4.39545 0,0 z m 206.63103,0.0887 c -1.27989,-2.76721 -1.23617,2.5608 0,0 z m -117.93854,-1.32709 c 13.52983,-3.14519 -17.52361,0.30058 0,0 z m 431.99405,0.19881 c -1.25392,-6.04858 -3.00919,4.89823 0,0 z m 5.98205,-2.43071 c -6.94295,-3.51055 -0.99736,6.85719 0,0 z m -389.58304,0.10502 c -2.69167,-0.69519 1.31068,3.2326 0,0 z m 456.76565,0.95454 c -0.59214,-2.97794 -0.85151,3.27975 0,0 z m -204.76885,-1.38857 c -2.05515,-3.34628 -2.06213,2.94513 0,0 z m -129.30347,-1.17027 c -1.73375,-2.16708 -0.5296,3.21382 0,0 z m 335.63395,0.29073 c -1.57095,-2.04413 -0.078,4.45366 0,0 z m -323.12536,-1.46245 c -1.97791,0.18091 2.7352,2.04093 0,0 z m 270.02639,-0.19015 c -2.72815,-4.5108 -0.41466,5.94506 0,0 z m 27.14909,-0.5173 c -1.51076,-7.64698 -4.08814,4.38179 0,0 z m -474.67378,-0.33045 c -2.2655,-1.48779 0.406,3.04316 0,0 z m 36.7216,-0.0568 c 5.17269,-24.52685 -21.50081,10.58812 0,0 z m -7.70754,-1.5617 c 0.72299,-2.19711 0.83296,2.4208 0,0 z m -0.46018,-6.66507 c 1.28025,-2.7673 1.23611,2.56092 0,0 z m -37.5026,7.74321 c -1.72436,-2.20506 -0.2472,3.27378 0,0 z m 479.41004,-0.77152 c -2.3831,-2.89392 -0.17003,4.83246 0,0 z m -476.64912,0.1886 c 6.09866,-2.94792 -9.48424,-2.58911 0,0 z m 158.74005,0.0815 c -0.70662,-3.9018 -4.67977,5.67395 0,0 z m 307.85677,-0.79534 c -1.61988,-3.46 -2.05653,1.69385 0,0 z m -281.24079,-1.41335 c -2.13502,-2.17629 -0.30893,3.80991 0,0 z m 268.80247,0.68558 c -0.47114,-5.59803 -4.26608,3.14808 0,0 z m 24.40236,-0.96518 c -0.13712,-4.30063 -1.82815,2.97504 0,0 z m -33.59135,-1.11083 c -0.86211,-3.00687 -1.67011,1.54728 0,0 z m -534.31621,-1.46245 c 8.55706,-5.98805 -8.30273,0.4861 0,0 z m 556.40364,0.59653 c -1.02151,-2.45297 -1.0218,2.45294 0,0 z m -37.7327,-0.24493 c -0.40159,-2.41195 -1.53482,1.43582 0,0 z m 42.85709,-1.00478 c 9.0359,-22.35664 -23.61943,-2.08475 0,0 z m -472.86692,0.12979 c 14.08396,-1.31632 -13.46608,-4.12763 0,0 z m 460.36612,-0.9629 -0.56687,0.0109 0.56687,-0.0109 z m 5.99599,1.06452 c 3.73694,-9.54863 -6.49657,-1.56024 0,0 z m 8.05268,-0.64801 c -0.98021,-2.40176 -1.05996,2.87102 0,0 z m -401.02474,-1.97677 c -1.72447,-2.20454 -0.24696,3.27352 0,0 z m 381.00803,0.31055 c -1.02149,-2.45279 -1.02171,2.45275 0,0 z m 7.36248,-2.24119 c -3.49108,-3.40044 -1.23585,5.79617 0,0 z m -340.9746,0.57487 c -1.23631,-2.56087 -1.27997,2.76726 0,0 z m 143.10811,-0.55537 c -1.23613,-2.56091 -1.28026,2.7673 0,0 z m 2.76093,0.31044 c -0.40179,-2.41194 -1.53488,1.43591 0,0 z m -82.59777,-0.86591 c -1.06011,-2.87102 -0.98002,2.40175 0,0 z m 265.59348,-1.21495 -0.0846,1.00342 0.0846,-1.00342 z m 7.89644,-0.86788 c 2.55291,-21.08558 -12.67551,-10.30214 0,0 z m -426.14388,0.55548 c -2.92258,-4.35647 -2.31435,5.08984 0,0 z m 155.09658,0.37492 c -1.31722,-2.8148 -1.31742,2.81479 0,0 z m 276.54608,-0.53638 c 0.9847,-6.69914 -4.44309,4.70161 0,0 z M 377.13457,629.5127 c -4.93241,-7.42287 -10.11458,5.82066 0,0 z m 32.82532,0.10472 c -1.68801,-1.82036 -0.29687,2.2941 0,0 z m -9.23754,-0.36987 c 0.12345,-4.97943 -2.66336,1.53447 0,0 z m 431.81926,-2.44454 c 15.52455,-9.20301 -9.24649,-2.14811 0,0 z m -417.22824,1.09279 c -3.42587,-4.6617 -2.14851,6.66719 0,0 z m 141.23996,-2.39358 -1.39816,1.51926 1.39816,-1.51926 z m 240.29023,0.0681 c -2.96012,-4.74944 0.38354,6.22059 0,0 z m 20.08321,0.16352 c -3.58727,-0.97364 1.72188,3.49457 0,0 z m 63.73685,1.56934 c -0.40178,-2.41195 -1.53488,1.43589 0,0 z m 2.30073,-0.86591 c -0.3098,-7.36107 -2.1182,3.65481 0,0 z m -479.94127,-1.3205 c -0.17333,-6.73913 -4.69763,2.50532 0,0 z m -138.95094,-1.49206 c 1.43906,-8.56689 -5.45692,4.80671 0,0 z m 429.20303,0.1396 c -1.58266,-2.57363 -0.56318,3.81576 0,0 z m 148.46654,-0.24293 c -2.91179,-6.96089 -0.94334,4.24353 0,0 z m -557.13779,-0.17354 c -1.54077,-7.35756 -6.93541,5.1391 0,0 z m 99.09266,0.31237 c -2.95191,-4.31479 -0.6771,2.17598 0,0 z m 494.45578,0.0382 c 11.48764,2.18637 -2.8251,-11.16529 0,0 z m -203.02867,-1.92835 c 2.64034,-8.21918 -4.49847,1.79793 0,0 z m 14.1156,0.22367 c -1.48503,-2.8134 -1.48482,2.81343 0,0 z m 158.68833,-0.23708 c 16.33068,-4.47384 -16.31227,-2.73252 0,0 z m 12.02899,-0.0733 c -1.60252,-2.06705 0.12879,3.01736 0,0 z m 7.36248,0.62099 c -0.40144,-2.4124 -1.53513,1.43591 0,0 z m 8.8317,-0.72716 c 0.60864,-7.29032 -11.90619,7.27214 0,0 z M 555.7944,621.42099 c -0.5065,-5.61642 -3.08683,2.12893 0,0 z m 301.17118,0.0175 c -1.23605,-2.56092 -1.28017,2.76733 0,0 z m 5.29184,-2.83865 c -4.75344,-1.55689 0.9614,6.32546 0,0 z m -21.72971,1.4186 c -6.04238,-14.80511 -15.94416,5.57101 0,0 z m -8.35262,-3.2633 c -1.61984,-4.34991 6.89962,4.78478 0,0 z m 34.22368,3.01703 c -2.5299,-3.28427 -2.7609,3.54584 0,0 z m -307.31084,-1.9999 c 5.57536,-12.58314 -6.9353,-5.43312 0,0 z m 297.64764,0.85641 c -2.05402,-3.01652 -1.66531,3.44351 0,0 z m -320.72779,0.0331 c -0.72253,-2.19719 -0.83334,2.42052 0,0 z m -271.67486,-1.75701 c -1.86289,-7.01434 -5.80377,5.04632 0,0 z m 410.18142,0.0908 c -1.02171,-2.45276 -1.02148,2.45278 0,0 z m -143.10811,-2.22171 c -0.76067,-6.28399 -0.72502,5.2734 0,0 z m -247.5632,0.23152 c -1.81983,-2.93128 -0.96321,3.72139 0,0 z m 537.69067,0.32396 c 0.64185,-4.22728 -3.33819,2.60652 0,0 z m -638.30342,-0.81382 c 2.82991,-6.82593 -4.54878,3.64959 0,0 z m 341.96389,0.25834 c -0.98046,-2.4016 -1.05972,2.87122 0,0 z m 36.03584,-1.07608 c -2.13495,-2.17681 -0.30936,3.81001 0,0 z m 322.0229,-2.55049 -1.99447,1.37183 1.99447,-1.37183 z m -303.07027,2.51572 c -0.72301,-2.19717 -0.83307,2.42094 0,0 z m -46.01547,-3.33253 c -0.72298,-2.19712 -0.83296,2.4208 0,0 z m 20.96291,-1.54241 -1.0281,1.71228 1.0281,-1.71228 z m 25.91006,1.19978 c 27.23165,2.11306 20.59774,-48.54611 -4.48823,-32.3438 -18.58292,-2.98098 -6.30751,-41.88821 -19.39528,-11.32722 -6.78608,14.90504 3.49096,18.78702 9.59447,20.21709 -12.734,11.07528 -13.36547,11.13145 -12.64091,14.5669 7.56267,11.69019 17.18952,-22.26225 24.59417,4.78543 l 2.33578,4.1016 0,0 z m 11.797,-7.10932 c -4.92941,-6.98904 4.93008,0.65053 0,0 z m -3.26856,-1.13746 c -1.97921,-4.69409 4.02726,2.59266 0,0 z m -12.83716,-4.48562 c -10.72061,-14.15387 3.92276,-22.97887 0,0 z m 13.11444,-15.83962 c 1.53488,-1.43589 0.4017,2.41197 0,0 z m -21.16712,-0.88488 1.89436,0.13242 -1.89436,-0.13242 z m -5.98197,-2.13716 c 1.53232,-3.67927 1.53235,3.67921 0,0 z m 27.26414,0.46529 c -2.6447,-2.79728 2.85419,0.41842 0,0 z m -33.2462,-2.38973 c 2.865,-8.54195 9.76808,0.58438 0,0 z m 7.80156,-3.39964 c -0.40171,-5.70748 2.81976,5.88625 0,0 z m -4.27366,-13.09741 c -2.51006,-5.87449 5.74518,0.78722 0,0 z m -298.02682,49.82025 c 5.2927,1.79414 -1.38749,-3.72135 0,0 z m 259.59194,-0.0175 c -1.2055,-3.64012 -2.47546,4.53318 0,0 z m 360.50812,-1.50103 c 13.96589,-27.67126 -24.99935,-13.14037 -31.81714,-14.25973 11.09966,1.3763 27.14345,1.98822 31.81714,14.25973 z m -323.76053,-0.3835 c -1.61976,-3.45982 -2.05648,1.69381 0,0 z m -30.97614,-2.66305 -0.0846,1.00352 0.0846,-1.00352 z m 48.65829,-1.30006 c 2.35705,-7.42187 -4.37903,4.71978 0,0 z m -48.51247,-1.3729 c -1.02172,-2.45275 -1.0215,2.45279 0,0 z m 217.98867,0.21986 -0.84448,0.0313 0.84448,-0.0313 z m -586.71838,-1.99028 -0.0846,1.00344 0.0846,-1.00344 z m 382.53435,0.65958 c -1.02149,-2.45279 -1.02172,2.45275 0,0 z m 173.01813,-1.07804 c -0.24691,-3.27356 -1.72454,2.20458 0,0 z m -189.3913,-0.92537 1.77966,-1.26279 -1.77966,1.26279 z m 170.52499,-0.21833 c -2.25064,-3.4145 -2.13549,3.11942 0,0 z m 8.66726,-0.75758 c -1.86032,-4.80206 -2.19243,4.43809 0,0 z m -160.51835,-0.0504 c 0.89476,-9.55069 -5.36979,0.28087 0,0 z M 688.549,597.31022 c -3.60801,-9.86288 -4.30386,5.355 0,0 z m 157.72468,0.46878 c 2.72884,-4.99071 -3.62989,0.10284 0,0 z m -324.99085,-0.77887 c -1.02156,-2.45273 -1.02157,2.45272 0,0 z m 175.77906,0 c -2.65879,-4.71381 -4.16569,4.34844 0,0 z m -7.13239,-0.55543 c -0.72273,-2.19713 -0.83312,2.42068 0,0 z m -5.85743,-0.65956 c -0.99582,-3.6833 -1.77327,2.91986 0,0 z M 534.43795,593.8093 c -2.97937,1.11457 3.17071,2.85321 0,0 z m 146.65489,0.91162 c -2.16971,-1.97402 -1.16531,2.55551 0,0 z m 158.14976,-1.19214 c -0.89512,-5.61959 -4.657,3.80505 0,0 z m -94.32461,-0.66148 c -0.86222,-3.00714 -1.67024,1.5474 0,0 z m 89.13584,-0.72706 c 5.01959,-5.27549 -3.30899,1.14735 0,0 z m -2.84264,-0.111 c 8.70108,-6.93361 -7.83373,-0.9081 0,0 z M 524.2495,590.84309 c -2.26574,-1.48781 0.40592,3.04329 0,0 z m 18.96195,-0.80966 c -0.69932,-4.17029 -2.4131,4.88875 0,0 z m -3.98263,-1.92001 c -0.83313,-2.42067 -0.72273,2.19713 0,0 z m 80.52706,-1.17027 c -2.04358,-2.60772 -0.92534,3.53718 0,0 z m -74.55209,-1.7457 c -2.99451,-2.32079 1.88873,7.15083 0,0 z m 287.83383,1.80513 c -1.05983,-2.87108 -0.9802,2.40158 0,0 z m -88.13425,-0.69428 c 0.63214,-10.55822 -3.42338,2.0196 0,0 z M 569.4281,584.89633 c -2.69661,-6.9424 -2.54022,4.28726 0,0 z m 33.03515,-0.18743 c -2.79912,-1.14058 0.64907,3.68482 0,0 z m -79.8,0.62741 c -0.83313,-2.42068 -0.72273,2.19713 0,0 z m 95.252,-1.2824 c -0.71836,-7.88467 -5.10234,5.13785 0,0 z M 537.5842,582.1886 c 0.8044,-5.70028 -3.23123,3.11096 0,0 z m 68.77603,-0.97975 c 1.59801,-10.30503 -10.76549,11.23704 0,0 z m 138.042,0.0999 c 2.69563,-7.5404 -7.89,-0.94455 0,0 z m -129.70802,-0.69351 c -1.04187,-3.28297 -1.04197,3.28293 0,0 z m -35.61026,-2.20436 c -4.22543,-5.71735 1.67593,5.43854 0,0 z m 36.07038,-1.12818 c -1.46956,-5.72424 -1.91031,3.79331 0,0 z m 6.67226,0.27772 c -0.98003,-2.40176 -1.06007,2.87088 0,0 z m 136.43585,-0.27772 c -1.27204,-3.53886 -1.16939,3.35802 0,0 z m -177.11179,-0.99763 c -2.52851,-1.51743 0.92398,3.19787 0,0 z m 37.25507,0.70039 -0.88736,-1.94794 0.88736,1.94794 z m 105.65517,-1.98096 c -5.24653,-1.9242 4.78196,5.70128 0,0 z m 6.02658,1.16736 c -0.58214,-4.97456 -1.18434,4.89507 0,0 z m -200.67895,-0.73217 c -5.78227,-1.60404 1.71594,2.75195 0,0 z m 47.553,1.00989 c -0.72273,-2.19713 -0.83313,2.42068 0,0 z m 8.12475,-0.83816 c -0.55915,-3.34795 -1.66984,7.47492 0,0 z m 125.48982,0.0383 c -9.4872,-11.84484 -41.20048,-1.23191 -12.29943,-2.13918 4.00566,0.3682 8.07544,3.90794 12.29943,2.13918 z m 7.56992,0.11129 c -3.27848,-10.47167 -1.39546,7.33788 0,0 z m -180.75781,0.13318 c -1.02164,-2.45298 -1.02165,2.45297 0,0 z m 75.4654,-0.27772 c -1.04198,-3.28293 -1.04189,3.28296 0,0 z m -64.42168,0.0329 c -0.40158,-2.4122 -1.535,1.43595 0,0 z m 208.21999,-0.31047 c -1.44656,-2.72234 -1.5389,3.07385 0,0 z M 578.544,573.61775 c -3.12662,-1.0201 0.0415,4.01566 0,0 z m 24.92504,-0.95763 c -2.19834,1.99655 5.75558,3.72092 0,0 z m -29.46675,1.50579 c -0.069,-6.60055 -4.65181,3.47147 0,0 z m 22.49634,-1.08685 c 10.20672,-2.64695 -1.85967,-4.39607 0,0 z m 4.39095,1.14895 c -0.83314,-2.42067 -0.72274,2.19712 0,0 z m 144.94872,-0.0776 c 0.50402,-8.76315 -4.81683,2.28473 0,0 z m -130.22377,-0.18957 c -1.40362,-6.67502 -6.66724,5.89376 0,0 z m 3.68123,-2.31572 -1.78863,1.31094 1.78863,-1.31094 z m -82.64008,0.0834 c -3.24869,-6.49196 0.20821,4.26335 0,0 z m 39.96077,-0.10833 c 2.33062,-6.54147 -7.86777,6.6822 0,0 z m -44.7501,-1.02916 c -1.69339,-4.27836 -1.62969,4.67217 0,0 z m 22.25385,0.58206 c 10.89902,-5.18517 -3.62327,-6.24555 0,0 z m 158.12675,0 c -1.04197,-3.28311 -1.04196,3.28312 0,0 z m -110.36518,-2.31106 c -2.12507,-4.22778 0.0579,7.44369 0,0 z m -14.56675,1.20025 c -2.20415,-3.87644 -2.20417,3.87642 0,0 z m -6.21206,-0.83314 c -0.83329,-2.4208 -0.72283,2.19723 0,0 z m 13.89661,-0.11108 c 3.00907,-8.33869 -8.05161,-0.2138 0,0 z m 149.91842,-0.44433 c -0.83313,-2.42068 -0.72273,2.19711 0,0 z m -160.594,-1.66627 c -1.48481,-2.81342 -1.48481,2.81342 0,0 z m 5.98207,-0.2777 c -1.04188,-3.28299 -1.042,3.28291 0,0 z m 6.67218,0.2777 c -1.23613,-2.5608 -1.28002,2.76726 0,0 z m 192.46575,-1.27841 c 1.2184,-7.4232 -6.97374,9.57149 0,0 z m -201.61535,-0.16976 c 0.6016,-10.23681 -4.31029,5.85386 0,0 z m 18.81288,0.89274 c -0.72273,-2.19713 -0.83312,2.42068 0,0 z m 5.53435,-0.97085 c -1.52098,-7.42997 -0.85484,4.71505 0,0 z m -12.66672,-0.13999 c -1.02156,-2.45272 -1.02155,2.45273 0,0 z m 145.68065,-1.45747 c -2.9747,-1.48755 1.44944,3.67363 0,0 z m -161.76287,-3.11158 c -0.81179,-11.06464 -2.0568,14.00032 0,0 z m 8.71974,2.59227 c -2.13784,-2.89479 -0.20227,4.41997 0,0 z m 12.0642,1.11519 c -0.78309,-11.38715 -6.04826,-0.73843 0,0 z m 4.04118,-2.08658 c -3.759,-2.64031 -0.91383,4.90369 0,0 z m -10.23837,0.30989 c -2.0607,-10.84998 -8.85708,1.27672 0,0 z m 16.55258,0.34889 c 2.81514,-5.01034 -4.00955,1 0,0 z m -34.63722,-1.84007 c 12.13486,-10.29846 -6.80397,-3.28953 0,0 z m -0.61413,-3.05181 c -0.90293,-2.87735 2.35571,1.5814 0,0 z m 31.00213,2.77094 c -3.91613,-0.63015 3.89608,4.74074 0,0 z m -24.15243,1.07776 c -1.2362,-2.56086 -1.28008,2.76733 0,0 z m 159.13913,-0.1844 c 1.54244,-6.14649 -6.59115,5.0716 0,0 z m -175.2445,-0.37101 c -1.02156,-2.45273 -1.02157,2.45272 0,0 z m -12.52961,-1.21498 c -0.99597,-3.68342 -1.77344,2.91993 0,0 z m -22.44216,-0.45128 c -1.23619,-2.56087 -1.28009,2.76731 0,0 z m 63.50137,-0.27772 c -1.18392,-3.02527 -0.83311,3.43974 0,0 z m -23.00775,-0.53799 c -1.88352,-2.54808 -0.60395,3.31227 0,0 z m 15.34192,-0.85057 c -2.15649,-9.41261 -7.16167,6.59411 0,0 z m 21.93059,1.11085 c -1.75515,-3.15557 -1.71262,2.87346 0,0 z m 2.99291,-0.90012 c -3.71375,-3.25388 1.20426,4.17013 0,0 z m 138.73469,0.32727 c -0.50662,-5.61643 -3.08675,2.12909 0,0 z m -151.85101,-1.68161 c -1.48708,-2.07547 -0.15882,3.03339 0,0 z m 5.52186,0.5882 c -1.2801,-2.76732 -1.23621,2.56086 0,0 z m -59.82013,-0.85267 c -2.66071,-2.19535 -1.15825,3.77542 0,0 z m 25.97407,-2.1e-4 c -0.51165,-5.47696 -4.50689,7.18304 0,0 z m 9.66646,-1.76552 c 2.11255,-19.26134 -4.95504,3.21554 0,0 z m -30.76093,0.54715 c -2.38561,0.0195 1.69788,2.43612 0,0 z m 42.43502,0.21364 c -2.37791,-3.89188 -1.53439,4.97436 0,0 z m 24.54706,-1.06798 c 12.29265,-10.10298 -7.76523,-3.4134 0,0 z m -9.28062,0.14849 c -1.31438,-5.44758 -0.87372,6.53694 0,0 z m -64.88179,0.2777 c -1.04197,-3.28293 -1.04188,3.28297 0,0 z m 59.69456,-2.48536 c -2.27101,-8.66005 -1.49841,8.22097 0,0 z m 127.86766,1.88451 c 7.8e-4,-5.8498 -2.96538,2.99505 0,0 z m -160.22064,-0.014 -0.64089,-1.03549 0.64089,1.03549 z m 5.12765,-3.22941 c -0.6912,-12.62573 -5.33644,8.27428 0,0 z m -19.29735,1.854 c 7.76899,-2.7648 -0.1324,-19.69976 0,0 z m 32.00347,-0.12837 c -4.71009,-13.23223 -0.58407,5.80703 0,0 z m 11.88385,0.17466 c 5.98328,-9.97865 -7.9417,-0.21381 0,0 z m 152.99534,-0.32919 c 5.82294,-7.2944 -8.96523,-6.38745 0,0 z m -161.95681,-1.35967 c 8.97244,-1.61987 -6.50506,-6.08658 0,0 z m 138.89463,-0.143 c -0.17628,-5.31063 -4.19486,3.57603 0,0 z M 598.58884,550.9002 c -1.02157,-2.45272 -1.02156,2.45273 0,0 z m -47.41061,-0.41657 c 1.29137,-4.58713 -3.26205,0.31811 0,0 z m 37.08429,-0.19197 c 0.2654,-9.13818 -6.43984,2.65844 0,0 z m 21.83015,0.0532 c -0.83313,-2.42068 -0.72273,2.19713 0,0 z M 764.7046,548.9563 c -1.09828,-4.99223 -2.00116,4.06888 0,0 z m -164.01513,-0.9442 c -2.34145,-11.56645 -1.9689,6.00307 0,0 z m 5.26184,0.88579 -1.36537,0.30939 1.36537,-0.30939 z m -66.03219,-0.21829 c -1.28008,-2.76732 -1.23621,2.56085 0,0 z m 15.20071,-1.5548 c -2.99453,0.72293 2.07592,2.95968 0,0 z m 212.34545,0.99992 c -1.22013,-3.94743 -2.16801,4.97624 0,0 z m -19.32625,-5.4e-4 c -0.83313,-2.42067 -0.72273,2.19713 0,0 z m -150.24049,-0.55542 c -1.28001,-2.76727 -1.23613,2.5608 0,0 z m -6.21206,-1.11086 c -1.02165,-2.45295 -1.02164,2.45298 0,0 z m -36.90436,-0.66649 c 1.8734,-6.21494 -4.45812,4.61217 0,0 z m 28.96663,-0.76841 c -2.63774,-0.94304 0.60699,3.15268 0,0 z m 5.01243,0.60178 c 0.40747,-7.0561 -6.46173,4.2547 0,0 z m 186.98714,0.27771 c -1.93507,-3.08946 -1.93508,3.08945 0,0 z m -196.94618,-2.00875 c -2.81993,-4.15678 -0.64551,7.01308 0,0 z m 26.1563,-0.22522 c -7.12367,-12.17515 -6.45436,4.46502 0,0 z m 8.08756,1.34142 c -0.86707,-6.12861 -6.26425,3.22214 0,0 z m 166.49861,-0.99148 c 13.74507,-7.64497 -6.04527,-4.86425 0,0 z m -203.5034,-0.61537 c -1.04197,-3.28311 -1.04197,3.28311 0,0 z m 31.52063,-0.5941 c -2.30326,-7.10228 -1.62804,6.76031 0,0 z m -14.49486,0.0907 c -2.36975,-2.95864 -1.52411,3.76127 0,0 z m 4.14135,-0.60742 c 6.21505,-13.60393 -6.68132,-6.80333 0,0 z m -23.26348,0.32782 c 2.57088,-6.07528 -4.70758,0.61553 0,0 z m 42.75641,-0.88325 c -2.76756,-1.56981 1.42691,-2.76013 0,0 z m 168.46598,-0.861 c -3.45479,-2.96136 -0.65063,4.6191 0,0 z m 1.71685,-0.63863 c -2.76401,-1.61995 1.45191,3.0557 0,0 z m -186.51797,-0.93339 c -2.93535,-1.20966 0.76091,3.73849 0,0 z m 10.18666,1.04445 c -1.02164,-2.45298 -1.02165,2.45297 0,0 z m -54.75838,-0.89255 c -2.18927,-4.45022 -1.73537,4.08615 0,0 z m 21.00865,-1.04747 c -3.87611,-8.9561 -0.63885,5.03904 0,0 z m 37.96784,0.82917 c -0.46832,-4.86088 -4.32489,5.13817 0,0 z m -42.87103,0.3105 c -0.40169,-2.41198 -1.53489,1.43586 0,0 z m 20.79129,-0.98626 c -1.97766,0.18231 2.7357,2.04034 0,0 z m 198.4425,0.16014 c 0.47792,-8.34165 -6.47867,4.78658 0,0 z m -200.82759,-0.66 c -2.8775,-5.17082 -3.97269,4.17088 0,0 z m 13.50376,-1.6464 c 13.76076,2.59598 -8.58839,-6.97216 0,0 z m -1.28682,-2.02731 c -1.17111,-9.11248 4.95632,3.43772 0,0 z m 3.15043,3.41067 c 0.16758,-5.70959 -2.78444,4.71348 0,0 z m 7.18017,-0.50531 c -1.04189,-3.28296 -1.04198,3.28293 0,0 z m 83.74818,0.2777 c -1.02157,-2.45272 -1.02156,2.45273 0,0 z M 551.65305,536.4603 c -1.48499,-2.81356 -1.48497,2.81361 0,0 z m 33.00909,-3.63299 c -0.11646,-8.94137 -6.28294,13.67771 0,0 z m -10.92166,1.68903 c -1.46968,-5.72442 -1.91035,3.79337 0,0 z m 49.30781,-0.61305 -1.33145,-0.15051 1.33145,0.15051 z m -64.72298,-0.22008 c -1.75528,-3.15578 -1.71279,2.8736 0,0 z m 33.78384,-1.31527 c 4.61176,-9.56266 -5.53062,4.16354 0,0 z m 97.30263,0.87218 c 1.18659,-4.24504 -3.14592,1.37529 0,0 z m -123.95409,-0.87747 c -0.0696,-8.56583 -4.46059,4.50506 0,0 z m 2.96624,-1.13937 c -4.31514,-2.18023 2.21678,4.65275 0,0 z m 11.26613,0.31126 c -0.29818,-5.09175 -3.13502,5.20244 0,0 z m -4.78301,-0.41462 c 5.08384,-6.84858 -6.21997,2.24061 0,0 z m 24.69159,0.38795 c 10.50672,-4.49835 -9.73417,-4.32924 0,0 z m 156.18554,-1.29606 c 9.57014,-14.75517 -14.48955,-4.59717 0,0 z m -174.06631,-0.2777 c -0.90053,-9.47725 -4.56808,-0.0424 0,0 z m -20.40161,-0.93921 c -0.68457,-7.00122 -3.13759,5.39828 0,0 z m 28.5296,-0.25107 c -1.04963,-5.27143 -2.30518,4.36449 0,0 z m 140.80729,0.0513 c 0.34145,-8.22549 -7.77703,2.88845 0,0 z m -135.36339,-1.61221 c 4.30474,-8.31653 -6.6581,3.61359 0,0 z m 129.38142,0.946 c -1.48498,-2.8136 -1.48498,2.8136 0,0 z m -151.3909,-1.11084 c -1.6701,-4.58877 -1.71724,4.54034 0,0 z m 9.6197,0.13886 c -1.87758,-5.16065 -0.30498,2.91775 0,0 z m 22.48566,0.31242 c -0.99591,-3.68333 -1.77335,2.9199 0,0 z m -35.7866,-0.45128 c -0.72273,-2.19713 -0.83313,2.42068 0,0 z m 156.22255,0 c -0.72267,-2.19733 -0.83327,2.42065 0,0 z m -138.96676,-0.55536 c -1.23614,-2.5608 -1.28001,2.76727 0,0 z m 137.25076,-0.45128 c -1.58269,-2.57372 -0.56331,3.81593 0,0 z m -142.31063,-0.66309 c -2.23377,-3.64772 -2.18648,3.9422 0,0 z m 21.85554,-1.90076 c -3.49996,-2.99113 0.57754,9.7759 0,0 z m -43.35089,0.77323 c -3.72159,-8.35888 -6.43386,9.18882 0,0 z m 38.28923,0.29793 c -1.04189,-3.28296 -1.04197,3.28294 0,0 z m 163.55784,-0.0176 c 11.40491,-1.08409 3.80571,-6.82008 -1.31395,-1.253 l 1.31395,1.253 z m -175.75726,-1.35078 c 21.87929,-13.32339 -4.06571,-16.43737 0,0 z m 5.29706,-1.02756 c -4.07792,-2.43975 0.80418,6.05546 0,0 z m 23.92805,1.5629 c -1.02156,-2.45273 -1.02157,2.45272 0,0 z m 6.50635,-2.2217 c -3.41772,-5.62252 -4.066,10.63517 0,0 z m -48.3804,1.38856 c 2.08487,-11.89998 -5.25727,0.82536 0,0 z m 153.23142,0.58821 c -0.40157,-2.4122 -1.53499,1.43594 0,0 z m -155.99235,-2.31392 c -2.64657,-4.62591 -2.02553,4.6603 0,0 z m 30.27005,-0.13247 c -2.34447,-2.82614 -1.13301,4.14618 0,0 z m -18.13969,-0.36353 c -0.59186,-2.97804 -0.85164,3.27971 0,0 z m -24.7846,-0.2777 c -1.28009,-2.76734 -1.23621,2.56086 0,0 z m 17.946,-1.11086 c -0.98012,-2.4017 -1.05999,2.87114 0,0 z m -23.69795,-2.25446 c -1.72437,-2.20483 -0.24718,3.27364 0,0 z m 14.95702,0.0289 c 0.21144,-7.93833 -5.62279,1.57314 0,0 z m 12.65226,0.34103 -1.09903,-0.37258 1.09903,0.37258 z m 175.12338,-1.69413 c 2.11061,-10.61062 -5.38028,6.4895 0,0 z m -172.4545,0.13506 c -0.34471,-9.89452 -6.69841,3.09049 0,0 z m 17.11774,0.11109 c -1.48481,-2.8134 -1.48481,2.8134 0,0 z m 2.76093,-0.86591 c -1.72443,-2.20499 -0.2472,3.27373 0,0 z m 144.6947,0.17164 c 6.64537,-8.42549 -4.50929,-0.36924 0,0 z m -178.56623,-1.20711 c 8.74454,-4.32524 -4.18962,-3.07849 0,0 z m 20.06688,-0.56524 c -0.89191,-4.35855 -2.26939,3.70158 0,0 z m 10.12341,-1.16104 c -0.32149,-7.3534 -3.48252,3.64464 0,0 z m 4.60155,-0.29308 c -1.72445,-2.20493 -0.24717,3.27376 0,0 z m -21.16712,-0.1995 c 4.50467,-8.01649 -4.74266,1.31345 0,0 z m 122.4011,-0.32313 c -1.02157,-2.4528 -1.02157,2.4528 0,0 z m -124.80791,-2.22169 c -3.07183,-8.22131 -2.25252,6.96074 0,0 z m 26.53513,1.72446 c -1.55974,-3.12583 -2.23841,4.11913 0,0 z m 148.43893,-0.34933 c 0.071,-4.43618 -3.18908,5.45008 0,0 z m -182.92076,-0.26429 c -0.72273,-2.19712 -0.83313,2.42067 0,0 z m 3.91134,-0.27771 c 0.18477,-7.33691 -5.53584,4.73266 0,0 z m 24.84837,0.27771 c 18.14307,-7.36313 -10.65274,-1.75461 0,0 z m -0.69022,-1.66626 c 0.72274,-2.19713 0.83313,2.42068 0,0 z m -45.32527,1.11084 c -1.02165,-2.45297 -1.02164,2.45298 0,0 z m 13.34453,-1.69904 c -1.72435,-2.20484 -0.24719,3.27359 0,0 z m 24.73297,-1.35467 c -2.64193,-6.70006 -1.78914,8.43301 0,0 z m 157.48826,0.83203 c -1.02156,-2.45273 -1.02157,2.45272 0,0 z m -187.19092,-0.66656 c -2.51743,-2.58858 -0.4956,2.73398 0,0 z m 26.21083,0.39196 c 4.58136,-9.71479 -7.30778,2.73796 0,0 z m 166.50194,-0.16978 c 14.74776,-14.3689 -14.29498,-8.95533 0,0 z m -169.77153,-0.90706 c 5.32119,-7.36338 -6.67575,0.0335 0,0 z M 553.50495,505.618 c 4.20081,-9.39427 -4.72164,0.99617 0,0 z m 158.28189,-0.29404 c -1.72435,-2.20486 -0.2472,3.27359 0,0 z m -136.20575,0.0328 c -0.72283,-2.19721 -0.83326,2.42081 0,0 z m 114.57852,0 c -0.72291,-2.1971 -0.83311,2.42071 0,0 z M 571.2947,504.16931 c 14.29462,-0.65919 -6.22826,-5.38203 0,0 z m 11.17338,0.21546 c 1.61998,-9.11104 -5.59176,2.37503 0,0 z m -15.62997,-0.69428 c -1.02164,-2.45297 -1.02164,2.45297 0,0 z m 24.61826,0 c -1.06008,-2.87088 -0.98002,2.4018 0,0 z m -36.58228,-1.38855 c -1.04197,-3.28312 -1.04197,3.28312 0,0 z m 42.4751,0.47796 c 0.27782,-3.53969 -2.94399,2.3745 0,0 z m 150.32973,-2.48756 c -2.05587,-1.11489 0.25912,2.93289 0,0 z m -161.97441,-0.55545 c -2.05586,-1.11489 0.25911,2.93288 0,0 z m 178.55613,-0.2357 c 1.91465,-8.01638 -5.59622,4.02882 0,0 z m -185.37662,-0.44261 c 0.25525,-6.47429 -4.93867,6.33138 0,0 z m 17.8642,0.18848 c -1.02156,-2.45272 -1.02155,2.45273 0,0 z m 171.17751,-0.83316 c -0.93152,-3.02494 -1.76621,5.30216 0,0 z m -19.91167,-1.00799 -1.28255,0.0385 1.28255,-0.0385 z m 2.40459,-1.24089 c -1.84262,-14.51727 -4.12387,4.73599 0,0 z m -155.97124,1.56817 c -0.76938,-7.57107 -11.45982,-1.84512 0,0 z m 11.34056,-1.1244 c -1.98049,-4.16429 -1.14815,6.70009 0,0 z m -21.00378,0.72705 c -0.40169,-2.41198 -1.53489,1.43587 0,0 z m 13.02366,-0.58059 c -1.62765,-3.42857 -1.68063,3.48843 0,0 z m 10.4442,-0.56303 c -0.59207,-2.9779 -0.85142,3.27981 0,0 z m 163.23987,-1.39671 c 20.29862,-6.92593 -11.14199,-2.64898 0,0 z m -195.45071,1.119 c -1.02164,-2.45298 -1.02165,2.45297 0,0 z m 191.32911,-0.48837 c -3.22037,-3.4566 -2.64382,4.43084 0,0 z m -13.86107,-4.69591 c -4.6242,0.57822 7.93222,11.39924 0,0 z m -209.67888,3.27308 c -0.40158,-2.41223 -1.53501,1.43597 0,0 z m 40.03352,-0.86591 c -1.02156,-2.45273 -1.02157,2.45272 0,0 z m 29.79428,-0.80092 c -0.62378,-7.25639 -2.88252,1.14853 0,0 z m -12.86852,-0.50674 c 0.20607,-8.20523 -6.95816,8.84612 0,0 z m 2.40074,0.19683 c -1.55684,-4.50732 -1.55685,4.50729 0,0 z m 2.14192,0.25374 c -0.0379,-4.19703 -2.20277,3.82509 0,0 z m -28.14069,-0.80917 c -0.72273,-2.19713 -0.83313,2.42067 0,0 z m 14.14689,-1.78722 c -5.04178,-3.49571 6.31262,7.46172 0,0 z m 4.0292,0.95408 c -1.46949,-5.72436 -1.91044,3.79319 0,0 z m -20.24681,0.0329 c -0.40157,-2.41223 -1.535,1.43598 0,0 z m 10.58361,-0.31047 c -0.83328,-2.42081 -0.72285,2.19721 0,0 z m 161.96731,-0.13886 c 1.74857,-6.5606 -4.03305,1.64989 0,0 z M 610.78288,489.2495 c -0.72273,-2.19711 -0.83313,2.42068 0,0 z m -15.94272,-0.94574 c 6.77708,-1.09246 -5.83609,-2.41655 0,0 z m 3.28848,0.70081 c -0.40157,-2.41221 -1.535,1.43596 0,0 z m 91.91532,-1.46735 c 0.75362,-7.62142 -4.39079,4.38939 0,0 z m -85.97199,-0.24557 c 1.16522,-7.70578 -5.17346,4.0249 0,0 z m 2.47365,0.15273 1.57266,-0.21153 -1.57266,0.21153 z m 142.05361,0.17164 c -0.91087,-4.47859 -2.63509,3.5115 0,0 z m 5.41065,-1.26864 c -2.82672,-1.88324 0.99462,4.71594 0,0 z m -68.54003,0.63878 c -1.31735,-2.81468 -1.31736,2.81465 0,0 z m -104.37399,-0.93033 c 1.07035,-4.26285 -3.09011,0.97206 0,0 z m 28.0765,-0.69963 c -1.09123,-5.41741 -2.89319,3.40902 0,0 z m 1.60898,0.002 c 9.8168,-1.10984 -1.57768,-8.80884 0,0 z m 93.54541,-1.1837 c -1.87216,0.90851 1.79459,2.29726 0,0 z m -112.64027,0.0761 c -1.60414,-4.81044 0.0138,3.59326 0,0 z m 4.60155,-0.58821 c -1.72445,-2.20496 -0.24719,3.27376 0,0 z m 6.90236,-0.24493 c -1.04189,-3.28297 -1.04198,3.28293 0,0 z m 3.22104,-0.89256 c -2.72333,-3.20479 -0.84049,4.7655 0,0 z m -5.51262,-0.78713 c -0.98226,-5.28019 -3.75533,4.88428 0,0 z m -7.55386,-2.33555 c -2.38571,0.0197 1.69805,2.43614 0,0 z m 12.14617,-1.34625 -1.48005,1.97301 1.48005,-1.97301 z m 13.80464,2.06173 c -0.13734,-4.30056 -1.82802,2.97524 0,0 z m -20.24681,-2.53217 c -2.18348,-4.04408 -4.58768,2.17369 0,0 z m 17.48588,-0.87421 c -4.70758,-8.70124 -6.56142,4.90645 0,0 z m -14.35296,0.27714 c -1.31735,-2.81467 -1.31736,2.81466 0,0 z m 4.68976,-0.51378 c -0.72291,-2.1971 -0.83311,2.42071 0,0 z m 1.65223,-0.90204 c -2.97461,-1.48751 1.44952,3.67353 0,0 z m -21.03139,-0.80345 c -2.35573,-1.58129 0.90304,2.8773 0,0 z m 31.04188,0.17808 c 11.2365,-14.22188 -7.7506,-0.0246 0,0 z m -18.56509,-1.82465 c -2.95419,-1.69551 -0.10485,4.55988 0,0 z m 5.25945,1.19353 c -0.79517,-3.25351 -2.41902,2.12227 0,0 z m 161.18959,-0.43601 c -2.46731,-2.29927 -1.1658,3.84242 0,0 z m -156.85669,-1.59152 c -2.87582,-6.42228 -2.69255,4.56586 0,0 z m 5.86368,0.0217 c 6.14937,-9.00962 -7.78639,-0.63313 0,0 z m -34.32233,0.58692 c -0.86224,-3.00713 -1.67023,1.54743 0,0 z m 9.98091,-1.11716 c -3.24291,-3.87264 1.53557,3.73642 0,0 z m 4.62899,1.01202 c 5.14866,-4.67776 -5.75373,0.67876 0,0 z m 7.68369,-0.15874 c 3.03033,-8.38665 -5.6731,1.41124 0,0 z m 144.58631,-1.05892 c 6.61292,0.0122 -1.27294,-3.93832 0,0 z m -162.27835,0.5249 c -0.96727,-4.93423 -3.53325,3.76979 0,0 z m 184.22757,-0.60131 c -4.0649,-9.48623 -6.69866,8.66084 0,0 z m -182.07813,-0.33455 c 1.31362,-6.78941 -3.75847,2.41525 0,0 z m -26.99781,-0.7984 c -1.28009,-2.76732 -1.2362,2.56086 0,0 z m 20.24682,0.0594 c -0.92545,-3.53712 -2.04363,2.60774 0,0 z M 605.28,469.77267 c -0.35669,-3.641 -2.82353,3.64658 0,0 z m 12.78442,-0.18644 c -0.0645,-3.75541 -2.08969,3.61373 0,0 z m -10.04537,-2.56492 c -4.58032,-3.54267 2.60593,7.61132 0,0 z m -13.6937,1.26038 c -1.3615,-8.24972 -9.41657,12.16318 0,0 z m -6.78023,-1.00423 c -1.60882,-3.2015 -0.32807,3.98936 0,0 z m 16.56558,-2.14052 c -5.34377,-1.80147 -0.11996,6.20421 0,0 z m 15.64518,2.7615 c -0.86209,-3.00694 -1.67013,1.54727 0,0 z m 131.98139,-0.96127 c 2.47624,-20.73512 -6.33476,5.03755 0,0 z m -154.52894,-0.46036 c -0.72273,-2.19713 -0.83313,2.42067 0,0 z m 14.26475,-0.83313 c -0.77448,-5.30143 -0.70026,4.45304 0,0 z m -22.93867,-1.11086 c -1.11109,-3.02317 -1.11106,3.02322 0,0 z m 17.40221,-0.69426 c 0.69823,-11.50064 -3.62157,3.21456 0,0 z m 16.62677,-1.08992 c -2.633,0.10912 4.07326,5.15267 0,0 z m -5.90342,1.20053 c -0.29981,-9.36138 -6.87841,1.8301 0,0 z m -19.69413,-0.78063 0.3154,-1.77149 -0.3154,1.77149 z m 5.99385,-1.49287 c -3.33237,-3.84014 0.84069,4.34886 0,0 z m 8.51339,-0.25708 c -2.04357,-2.6077 -0.92534,3.53717 0,0 z m -21.00069,-1.32913 c -1.09434,-3.77513 -1.27198,3.00865 0,0 z m 28.21735,-0.38186 -0.0846,1.00351 0.0846,-1.00351 z m -29.7642,-1.2844 c -1.04197,-3.28312 -1.04197,3.28312 0,0 z m 17.52042,0.12497 c -1.68802,-1.82032 -0.29677,2.29434 0,0 z m -2.33526,-0.35725 c 3.03165,-5.87431 -4.76893,2.11466 0,0 z m 8.2827,-1.15628 c -1.02164,-2.45298 -1.02165,2.45297 0,0 z m -26.68889,-0.83314 c -0.87952,-3.31849 -0.55569,2.98332 0,0 z m 300.33566,0.23088 c 4.02478,-5.50349 -3.99517,0.095 0,0 z m -278.70843,-0.81907 c -1.72443,-2.20499 -0.2472,3.27372 0,0 z m 3.22104,-0.83313 c -1.72445,-2.20497 -0.24719,3.27376 0,0 z m 4.95627,0.13692 c -1.82466,-3.31599 -1.78301,3.64777 0,0 z m -27.73391,-2.32583 c -3.04059,-0.95067 1.26387,3.66607 0,0 z m 14.52973,0.20233 c 1.84035,-5.31714 -7.89194,7.72479 0,0 z m 8.9382,0.3531 c -0.72267,-2.19733 -0.83327,2.42064 0,0 z m -49.30019,-0.83315 c -3.27099,-6.84555 -3.74467,2.25195 0,0 z m 29.28348,-0.34326 c -2.05593,-1.11491 0.2591,2.93291 0,0 z m 23.35281,0.82633 c 11.88242,-6.66251 -47.2532,-15.56194 -7.30133,-3.33335 3.00339,0.005 5.07728,1.81482 7.30133,3.33335 z m -18.29114,-1.62669 c -1.60271,-2.0669 0.12882,3.01737 0,0 z m 8.93419,-1.49462 c -3.09473,-5.52413 0.83762,4.17221 0,0 z M 594.9076,449.0138 c -0.4017,-2.41197 -1.53488,1.43591 0,0 z m 7.36248,-0.2777 c -0.5698,-3.27898 -1.81275,2.52258 0,0 z m 8.7429,0.0266 c -0.54861,-3.14178 -2.2453,1.82415 0,0 z m -29.7513,-1.47193 c -1.5258,-2.24324 0.61493,2.85593 0,0 z m 16.63686,0.30167 c -0.72273,-2.19713 -0.83313,2.42068 0,0 z m 19.55661,-0.52265 c -0.24718,-3.27364 -1.72438,2.20484 0,0 z m 3.53601,-3.06514 c -0.79748,-16.71065 -8.51614,-4.71014 0,0 z m -25.3095,0.75107 c 4.87593,-8.75103 -3.25314,-0.93392 0,0 z m 7.50873,0.33732 c -1.04198,-3.28293 -1.04189,3.28297 0,0 z m 4.14135,0.27771 c -1.62297,-4.69722 -4.37556,2.61341 0,0 z m -16.33547,-1.11085 c -0.72273,-2.19712 -0.83313,2.42069 0,0 z m 301.18802,-1.13109 c 9.3158,-6.11532 -5.9533,0.27806 0,0 z m -287.61348,-0.22437 c -0.40158,-2.4122 -1.535,1.43595 0,0 z m 7.82259,-1.42133 c -1.02165,-2.45298 -1.02165,2.45298 0,0 z m 9.89339,0 c -1.2801,-2.76732 -1.23621,2.56086 0,0 z m -37.04248,-0.77372 -1.09904,-0.37257 1.09904,0.37257 z m 13.34453,-1.51353 c -2.05593,-1.11489 0.25911,2.9329 0,0 z m 27.04362,0.51684 c -0.99597,-3.68347 -1.77346,2.91996 0,0 z m -22.11565,-0.79941 c -1.50454,-4.53537 -2.42602,4.01997 0,0 z m 18.37954,-2.15843 c 0.70384,-14.5291 -6.93977,2.95707 0,0 z m -7.20214,-0.85875 c -1.83439,-2.70797 -1.06461,3.46105 0,0 z m -33.59125,-1.35578 c -1.04189,-3.28296 -1.04198,3.28293 0,0 z m 44.63497,-2.35529 c -4.11814,-2.31983 0.10978,8.31297 0,0 z m 268.04004,0.96675 c -1.23609,-2.5607 -1.27997,2.76706 0,0 z M 612.8536,431.823 c -2.01492,-3.17123 -0.97084,4.18602 0,0 z m -9.4332,-1.44834 c -0.98004,-2.40178 -1.06007,2.8709 0,0 z m -6.1689,-1.1387 c 0.39468,-4.64818 -4.55872,4.72668 0,0 z m 9.66261,-0.24986 c -1.70209,-3.60107 -1.74261,3.3645 0,0 z m 256.72374,-1.94397 c -1.02165,-2.45297 -1.02165,2.45297 0,0 z m -239.51044,-0.55532 c -0.72267,-2.19733 -0.83327,2.42064 0,0 z m 236.74951,0.0329 c -0.2472,-3.27373 -1.72444,2.20498 0,0 z M 617.45515,424.5757 c -0.4017,-2.41196 -1.53489,1.43588 0,0 z m 235.59918,-1.69903 c -1.18378,-3.0253 -0.83309,3.43958 0,0 z m -243.62477,-5.51684 c 1.1861,-6.33505 -4.65982,5.35413 0,0 z m 6.0412,-1.47403 c 13.69009,2.93227 -5.62111,-6.23382 0,0 z m -6.7586,-2.27931 c -2.64076,-2.18106 -0.40648,3.01346 0,0 z m -4.14135,-0.7602 c -1.6027,-2.06689 0.12881,3.01735 0,0 z m -4.14135,-1.11879 c -2.16359,-3.41344 -1.54826,4.11998 0,0 z m 11.96394,-0.006 c -1.81995,-2.93129 -0.96293,3.7214 0,0 z m -10.12332,-0.23142 c -1.02156,-2.45273 -1.02157,2.45272 0,0 z m 192.34463,0 c -1.02156,-2.45273 -1.02157,2.45272 0,0 z m -203.72324,-2.25905 c -3.04348,-1.97499 1.52164,4.63886 0,0 z m 19.2012,1.14811 c -1.02156,-2.45272 -1.02155,2.45273 0,0 z m -4.31768,-0.55542 c 3.00666,-6.50389 -6.70656,4.39336 0,0 z m 182.39755,0 c -1.2801,-2.76731 -1.2362,2.56086 0,0 z m 43.92511,-0.51705 c 0.28123,-3.01776 -1.67417,1.91653 0,0 z m 1.90823,-0.9988 c -2.38579,0.0194 1.69785,2.43627 0,0 z M 595.74483,408.019 c -2.23825,-7.58412 -2.96351,6.25613 0,0 z m 5.42407,-0.18428 c 3.28818,-9.96329 -3.65605,3.76054 0,0 z m 7.3076,-2.46487 c -2.90403,-0.31198 1.42904,3.31205 0,0 z m -10.57796,0.56633 c -0.72273,-2.19712 -0.83313,2.42067 0,0 z m 15.41517,-0.83313 c -0.988,-3.18246 -1.97231,4.62826 0,0 z M 259.91497,956.92183 c 12.58158,-26.60958 54.22039,-28.04719 74.00416,-11.54006 -12.64807,-2.02143 2.69922,20.11952 -18.26838,14.16071 -18.70747,-2.30355 -37.08472,-2.35873 -55.73578,-2.62065 z m 70.40365,-2.78453 c -0.833,-2.4207 -0.72293,2.19721 0,0 z m -8.11551,-7.77584 c -2.46819,-7.93346 -3.72999,6.87268 0,0 z m -2.00789,-4.72111 c -1.46965,-5.72421 -1.91024,3.79328 0,0 z m 17.02577,15.82958 c 1.02144,-2.45308 1.02183,2.45287 0,0 z m 1.61052,0 -2.15693,-4.92525 2.15693,4.92525 z m 4.62411,-1.7558 c -4.86525,-29.7913 44.74864,-9.50599 12.61651,-0.26376 l -6.34962,0.94774 -6.26689,-0.68398 z m 6.81047,-6.8355 c -0.25146,-4.34829 -2.22324,3.41511 0,0 z m 7.2017,0.25988 c -1.23631,-2.56087 -1.27997,2.76726 0,0 z m 2.07072,8.33142 c 0.83292,-2.4209 0.72302,2.19707 0,0 z m 4.14136,0 c -1.03935,-2.46245 4.11534,3.47626 0,0 z m 2.53082,0.30257 1.54087,-0.36543 -1.54087,0.36543 z m 5.53776,-0.29085 3.84522,0.0374 -3.84522,-0.0374 z m 10.02126,0.1643 0.83108,0.10319 -0.83108,-0.10319 z m 64.05064,-0.56702 c 3.19383,-9.10297 6.7108,6.68776 0,0 z m 28.98689,0.40844 1.36521,0.30922 -1.36521,-0.30922 z m -91.87729,-1.82263 c -11.63092,-7.84843 4.62278,-8.90783 0,0 z m -5.56049,-1.11087 c 3.2497,-4.14122 3.22481,5.49583 0,0 z m -12.53919,-0.41186 c 3.07649,-7.27389 6.23536,4.26606 0,0 z m 23.23776,-1.67096 c 1.02171,-2.45275 1.0215,2.45276 0,0 z m -10.95414,-0.38874 c -1.94051,-4.21318 4.41609,2.34633 0,0 z m -42.91043,-0.77389 c -0.73276,-5.93032 4.78617,2.22036 0,0 z m 38.9096,-1.37744 c 2.1635,-3.41358 1.54827,4.12006 0,0 z m -30.55587,-0.70569 c -0.60327,-3.14903 2.61477,0.97342 0,0 z m 105.74936,-0.29558 c -1.60106,-3.96387 3.18401,1.39152 0,0 z m -63.31579,-0.17055 0.83116,0.10214 -0.83116,-0.10214 z m -9.57697,-1.00922 c 3.55214,-1.36481 -1.88323,-3.11493 0,0 z m 12.74305,-0.66659 c -5.35482,-5.14316 4.96936,-0.0623 0,0 z m -5.38057,-1.27737 c 0.83334,-2.42052 0.72253,2.19719 0,0 z m 63.21861,0.0495 c -7.69577,-10.32163 15.36544,4.05343 0,0 z m 11.60093,-1.07391 c -0.60318,-3.14894 2.61461,0.97341 0,0 z m 9.38875,-1.45782 c 2.04368,-2.60811 0.92559,3.53732 0,0 z m -8.28279,-2.51685 c 1.02149,-2.45278 1.02172,2.45274 0,0 z m -80.87211,-1.30286 c -2.67994,-7.52897 5.80742,5.89908 0,0 z m 68.56302,0.94135 c -0.31576,-4.57462 5.31174,4.06708 0,0 z m -73.95564,-0.72149 c -0.80862,-6.55469 3.87889,1.40738 0,0 z M 359.112,938.76844 c -1.05942,-5.39 2.98678,2.01196 0,0 z m 6.88826,-0.14485 c -0.28125,-3.01781 1.67418,1.9165 0,0 z m 23.21818,-0.0382 c 1.02149,-2.45279 1.02172,2.45275 0,0 z m 21.16712,0.17375 c -13.10829,-24.68792 20.95789,-10.68036 0,0 z m -26.91908,-1.28459 c 1.27998,-2.76725 1.23631,2.56087 0,0 z m 118.84508,-2.45094 c 4.96979,-4.38237 1.92958,4.98595 0,0 z m -335.04203,-0.69767 c -3.59685,-5.97874 8.47357,-2.85464 0,0 z m -6.2878,-4.07197 c 1.02171,-2.45274 1.02149,2.4528 0,0 z m -2.76093,-1.38847 c 0.87072,-3.16145 0.8712,3.1611 0,0 z m 4.25016,-2.03496 c -2.80141,-7.89594 5.41917,2.67481 0,0 z m 153.44956,-0.46447 1.1716,-0.17716 -1.1716,0.17716 z m -157.12447,0.18759 c -3.27366,-3.0251 3.03278,-0.21646 0,0 z m 94.21664,-0.74304 c 1.23632,-2.56087 1.27998,2.76726 0,0 z m 62.58106,-3.35574 c -6.7143,-10.8068 8.0989,-3.7789 0,0 z m 91.57077,0.0237 c 1.02179,-2.45294 1.0215,2.45297 0,0 z m -246.0244,-1.94826 c 0.41729,-6.17106 2.28291,6.89655 0,0 z m -2.79521,-0.31189 c -0.27652,-3.6919 1.33049,2.85887 0,0 z m 162.63103,-1.37248 c -3.31372,-11.05024 5.92146,5.3042 0,0 z m 186.27215,-1.92156 c 0.72301,-2.19719 0.83309,2.42091 0,0 z m -22.77765,-1.66622 c -17.73046,4.06061 -10.5287,-13.5046 0,0 z m -2.30073,-3.33253 c -0.72264,-2.19728 -0.83347,2.42068 0,0 z m -209.02525,3.01487 c -6.44129,-5.67053 4.95893,1.3286 0,0 z m 11.00986,0.0949 c -1.04773,-3.62938 2.72324,1.46362 0,0 z m -18.92793,-0.29445 c 0.79671,-11.83042 8.13889,3.71377 0,0 z m 13.09477,-0.59385 1.67788,-0.40772 -1.67788,0.40772 z M 158.54074,911.9572 c 0.86279,-4.57184 2.37243,3.34505 0,0 z m 309.11394,-1.18193 c -1.06268,-3.6085 2.74592,1.40489 0,0 z m 7.77925,-0.3999 c 2.96968,-4.44093 1.3257,3.74713 0,0 z m -158.22966,-0.67163 c -1.46504,-5.51061 4.11926,1.70533 0,0 z m -158.49711,-0.52153 c -9.0667,-19.25693 15.87975,-4.42711 0,0 z m 352.55774,-3.47058 c 0.9959,-3.68335 1.77336,2.91988 0,0 z m -353.0441,-7.6718 c 0.83347,-2.4207 0.72265,2.19727 0,0 z m 199.49795,-2.73622 c -20.88167,-30.00735 68.89369,-5.23634 16.54655,-2.15406 -5.53269,-0.24642 -11.52722,-0.84678 -16.54655,2.15406 z m 2.49844,-3.05396 c -3.4492,-0.10481 2.74135,3.627 0,0 z m 32.68249,-6.42901 c -1.48483,-2.81347 -1.48496,2.81345 0,0 z m -4.65412,-2.81637 c -2.35569,-1.58161 0.9028,2.87738 0,0 z m -103.17213,7.60682 c -31.26116,-10.58438 23.21944,-16.57963 0,0 z m 147.69812,-3.94218 c 2.41713,-9.00123 7.69725,5.20187 0,0 z m 5.91351,0.26247 c 1.23631,-2.56087 1.27998,2.76725 0,0 z M 271.41889,884.4321 c 0.85365,-4.50092 1.5514,2.49822 0,0 z m 161.0541,-3.0876 c 1.53498,-1.436 0.40169,2.41214 0,0 z m -46.93579,-0.52267 c 1.02171,-2.45274 1.02149,2.45279 0,0 z m -104.11559,-4.21877 c -0.42392,-8.4632 7.61679,4.20517 0,0 z m -7.01178,-11.33305 c 0.83347,-2.42067 0.72264,2.19729 0,0 z m 219.71246,-1.98015 c -4.4837,-13.15251 8.91763,-2.38232 0,0 z m 2.77237,-1.94056 c -1.86465,-2.97254 -0.10995,4.28699 0,0 z m -102.15436,0.033 c 1.02148,-2.45278 1.02171,2.45275 0,0 z m 1.3805,-1.66632 c -0.87249,-2.23074 3.05711,2.1582 0,0 z m 3.30925,-0.0413 c 1.3175,-2.81493 1.3173,2.81495 0,0 z m 1.58137,-2.62013 c 1.29094,-2.23649 1.7819,2.78994 0,0 z m -47.22486,-1.9945 1.79969,-0.28038 -1.79969,0.28038 z m 21.39714,-0.34242 c 0.83308,-2.42094 0.72302,2.19716 0,0 z m 23.24809,-1.01831 c -0.9474,-6.33828 9.02544,7.47819 0,0 z m 89.0619,-1.14045 c -0.28478,-4.1978 3.24134,1.88685 0,0 z m -87.95594,-1.91404 c -16.08533,-5.36808 11.60924,-14.26338 0,0 z m -45.52109,-1.48144 c 1.0215,-2.45297 1.02179,2.45294 0,0 z M 158.48048,847.8898 c 1.17726,-3.4785 0.27962,1.84791 0,0 z m 0.047,-4.65086 c -3.07838,-1.999 2.01725,-1.56091 0,0 z m 230.23075,-0.18518 c 1.28014,-2.76729 1.23601,2.5608 0,0 z m 2.53083,0 c 1.28026,-2.7673 1.23613,2.56091 0,0 z m 65.11189,-2.73961 c 2.11369,-6.19569 3.51333,5.70141 0,0 z m -59.97347,-13.73786 c -2.84876,-4.96549 3.84039,1.0535 0,0 z m -3.74219,-1.26529 c -0.47326,-5.08718 3.88326,2.71328 0,0 z m 6.65646,-0.27568 1.37641,-0.56511 -1.37641,0.56511 z m 5.62212,-5.32187 c 0.44024,-7.4237 4.95392,5.19937 0,0 z m -3.55141,-1.09826 c 0.83335,-2.42051 0.72254,2.1972 0,0 z m 4.23059,-3.13229 c -0.99703,-4.10472 2.77838,1.40986 0,0 z m -71.11574,-1.70139 c -31.89196,-9.33327 38.78117,-10.21401 3.5485,0.0404 l -3.5485,-0.0404 z m -0.63294,-1.93549 c -0.59124,-3.8352 -1.54343,2.58208 0,0 z m 17.82231,-2.4726 c 0.84627,-3.74661 -2.98137,1.94962 0,0 z m 3.4502,-4.61092 c 0.24698,-3.27353 1.72447,2.20455 0,0 z m -28.34685,-2.00699 c -4.50634,-13.15464 9.40225,-2.70272 0,0 z m 12.66621,-1.45647 c -3.87402,-8.7103 6.12637,-3.40406 0,0 z m 11.76298,-1.02521 c -1.45836,-7.21812 5.4598,1.35111 0,0 z m 85.59974,-1.66282 c 1.70627,-1.81299 0.67551,2.49194 0,0 z M 327.99943,786.06479 c -5.60965,-12.16681 9.44898,-6.21928 0,0 z M 316.5997,783.505 c -7.88064,-15.75921 12.87016,-3.02081 0,0 z m 34.42584,-1.54756 c 1.9381,-7.80035 2.8481,5.54044 0,0 z m -11.04372,-3.39733 c 2.67306,-14.71634 3.33444,7.8406 0,0 z M 327.90276,767.1987 c -9.70688,-18.13397 15.55845,-4.41091 0,0 z m 11.96436,0.48398 c -10.03088,-16.97881 12.99623,-7.0578 0,0 z m -23.23819,-0.56807 c -10.66261,-12.86167 15.6735,-8.05086 0,0 z m 34.44209,-1.9587 c -5.06505,-13.73465 7.84024,-0.35879 0,0 z m 20.31348,-0.78554 c -2.03304,-4.31619 3.54683,1.8494 0,0 z m -1.69292,-1.82015 c -1.53764,-6.57752 6.11537,-0.22685 0,0 z m 47.13606,2.1e-4 c 1.84244,-6.69927 3.14073,6.85209 0,0 z m 18.4062,0.58415 c -1.32343,-5.3605 3.64948,0.13527 0,0 z m -53.37796,-1.72781 c 1.02172,-2.45272 1.02147,2.4528 0,0 z m 34.74166,-1.66621 c 0.72253,-2.19721 0.83335,2.4205 0,0 z m -104.225,-16.69547 c 1.53488,-1.4359 0.40179,2.41195 0,0 z m 14.09842,-0.24494 c 1.29764,-3.02737 1.23423,4.62968 0,0 z m -6.27584,-0.27773 c 0.83348,-2.42068 0.72264,2.19728 0,0 z m 7.82268,-1.97676 c 1.72436,-2.20504 0.2472,3.27377 0,0 z m 126.24115,0.0103 c -0.17932,-4.04376 2.31956,3.70829 0,0 z m 210.59201,-83.01153 c 1.0215,-2.45278 1.02171,2.45275 0,0 z m 2.99565,-12.22835 c 1.70619,-1.81295 0.67551,2.49187 0,0 z m 148.85536,-11.96529 c 1.6026,-2.06725 -0.12799,3.01742 0,0 z m -7.13238,-0.24493 c 1.23614,-2.56091 1.28025,2.76731 0,0 z m -151.1608,-2.22167 c 1.0215,-2.45279 1.02172,2.45275 0,0 z m 11.63042,-0.58684 c -6.95699,-6.71716 6.3659,-0.32774 0,0 z m 134.23862,-3.85654 c 1.0215,-2.45299 1.0218,2.45293 0,0 z m -1.61052,-1.11084 c 1.05997,-2.87102 0.98022,2.40176 0,0 z m -133.2148,-0.83321 c 0.87966,-3.31831 0.55532,2.98337 0,0 z m 135.74564,-1.66619 c 1.11123,-3.02329 1.11122,3.02331 0,0 z m 6.90227,-0.33715 c 3.76112,-5.11174 2.57801,6.10612 0,0 z m -11.04363,0.0598 c 1.23626,-2.56089 1.27996,2.76733 0,0 z m -129.99376,-7.22037 c 0.7227,-2.19718 0.83333,2.42055 0,0 z m -510.3114,-2.22172 c 1.48484,-2.81346 1.48495,2.81346 0,0 z m 4.48368,-0.13886 c 3.60902,-4.99323 3.77835,4.41358 0,0 z m 7.48496,-0.98106 c 1.70626,-1.81306 0.67545,2.49195 0,0 z m 496.27213,-1.10176 c 1.02149,-2.45299 1.0218,2.45292 0,0 z m -37.96279,-4.99886 c -16.01134,-29.10405 47.74901,-27.23337 13.74361,-5.45739 -4.58591,1.78913 -9.35455,3.18526 -13.74361,5.45739 z m 4.83164,-4.13283 c -0.1371,-4.30064 -1.82814,2.97504 0,0 z m -3.22113,-1.42138 c -1.02178,-2.45294 -1.02149,2.45297 0,0 z m 178.53999,4.99885 c 1.02149,-2.45279 1.02172,2.45274 0,0 z M 629.41909,604.4693 c 1.60252,-2.06701 -0.12879,3.01733 0,0 z m 182.22122,-4.68829 c 1.02156,-2.45293 1.02173,2.45287 0,0 z m 0.48123,-7.72834 c -0.56336,-3.9254 1.94421,3.78945 0,0 z m -141.28852,-9.15306 c 1.61975,-3.46 2.05651,1.69397 0,0 z m -40.82484,-3.10369 c -9.35559,-28.66799 47.3921,-23.09621 13.9085,-2.93705 -4.35591,1.45684 -9.16883,6.49201 -13.9085,2.93705 z m 250.40047,-3.39149 c -1.20808,-4.0851 2.33839,1.7259 0,0 z M 649.6659,574.78656 c 1.93509,-3.08946 1.93508,3.08947 0,0 z m 215.3657,-3.86626 c -0.49729,-3.44106 3.21596,3.68322 0,0 z m 15.86195,-0.0217 c 0.72268,-2.19731 0.83326,2.42065 0,0 z m -22.95996,-2.54952 c -0.61093,-4.9082 2.70526,3.46868 0,0 z m 16.97799,-0.41831 c -16.26004,-3.93562 -64.87167,-1.22998 -49.39107,-28.3625 15.78089,7.21843 63.25346,-3.33288 49.39107,28.3625 z m -14.49486,-0.3647 c 1.02165,-2.45297 1.02164,2.45298 0,0 z m -14.93539,-1.07247 c -0.28214,-3.01764 1.67401,1.91617 0,0 z m -23.2575,-4.20403 c 1.53241,-3.67922 1.53243,3.67918 0,0 z M 625.11789,560.9948 c -1.49038,-6.52279 3.94926,5.47398 0,0 z m -3.30565,-0.12167 c -0.85381,-3.21825 2.47947,1.57778 0,0 z m 8.52339,-1.49952 c -15.27074,-27.57108 48.00043,-34.15835 14.55247,-7.87543 -4.76095,2.80174 -10.55672,3.80512 -14.55247,7.87543 z m 250.78801,-2.91596 c 1.02157,-2.45271 1.02157,2.45271 0,0 z m -142.85065,-3.26872 c -1.53603,-5.55338 3.83421,4.68822 0,0 z m 4.15853,-2.75415 c -0.60369,-3.14863 2.61485,0.97327 0,0 z m -115.31325,-0.6422 c 1.02157,-2.45273 1.02156,2.45274 0,0 z m 77.30601,-1.38855 c 1.04197,-3.28312 1.04197,3.28312 0,0 z m -79.14663,-4.16566 c 1.48489,-2.8134 1.4849,2.81339 0,0 z m 247.88921,-2.05358 c -15.69851,-7.43859 -63.15093,-2.03238 -49.03642,-30.17219 14.62811,7.10342 64.01633,1.8821 49.03642,30.17219 z m -13.92021,-16.79241 c 0.28214,-3.01765 -1.674,1.91616 0,0 z m 6.54611,-1.80878 -0.0846,1.00343 0.0846,-1.00343 z m -123.84024,16.26148 c -1.80807,-6.93285 5.18769,2.78378 0,0 z m 139.17112,-0.3741 c 1.79644,-2.90552 0.94585,3.71468 0,0 z M 619.1037,538.20325 c -2.29646,-2.30585 1.96977,-0.17142 0,0 z m 11.42246,-2.54352 c -15.56632,-24.58931 44.37318,-38.37706 15.09129,-9.43274 -4.84597,3.4478 -10.56315,5.50897 -15.09129,9.43274 z m -13.53129,-1.5785 c -2.17198,-14.93489 5.53737,0.70328 0,0 z m 262.05806,0.15952 c 1.2362,-2.56086 1.28009,2.76732 0,0 z m -253.77528,-3.05483 c 2.05419,-8.91762 2.00867,6.49557 0,0 z m 114.1184,-2.80988 c 1.72444,-2.20497 0.24718,3.27376 0,0 z m -28.56756,-3.60576 c -3.70692,-9.08356 6.49344,2.31938 0,0 z m -102.69123,-3.01349 c 1.91348,-3.72104 -0.36468,3.90627 0,0 z m 250.62432,-3.34644 c 0.18548,-6.91466 1.34288,4.29135 0,0 z M 610.85006,516.2009 c -8.73496,0.86669 4.68345,-5.88637 0,0 z m 262.72571,-0.42792 c -16.20218,-6.87592 -60.81895,-1.54586 -49.0201,-30.20349 13.62156,10.37483 63.57377,0.2578 49.0201,30.20349 z M 845.7263,493.54222 c -1.6881,-1.82063 -0.29703,2.29436 0,0 z M 618.23819,515.5611 c -13.26299,-10.47872 11.0622,-21.94694 -0.27543,-8.97803 2.60595,2.06075 3.69805,6.95744 0.27543,8.97803 z m -1.09392,-12.23401 c -0.23578,-6.04517 -5.05417,3.48511 0,0 z m -4.00074,9.66878 c -2.01656,-6.52173 2.47945,3.72777 0,0 z m 17.04509,0.27771 c -15.14938,-26.41526 47.01624,-41.2927 14.31921,-11.7697 -4.62845,4.09179 -9.24243,8.23036 -14.31921,11.7697 z m -8.74555,-2.73083 c -0.84409,-6.55864 5.44888,3.02617 0,0 z m 173.17156,-0.74055 c 1.02164,-2.45298 1.02165,2.45297 0,0 z m -169.33698,-1.3879 c -9.46628,-2.1743 7.39402,-6.59222 0,0 z m -6.90228,-11.97501 c 0.2974,-7.00859 3.80473,2.80392 0,0 z m 5.06166,-2.1889 c 0.83312,-2.4207 0.7229,2.1971 0,0 z m -3.68124,-2.41025 c -16.42014,-0.17962 0.67887,-6.90134 0,0 z m 253.39013,-1.89427 c -14.95282,-7.77867 -62.91769,-3.89084 -48.19501,-30.72438 14.85956,7.78132 60.51796,2.44292 48.19501,30.72438 z m -34.35652,-10.6591 c -0.24717,-3.27375 -1.72445,2.20492 0,0 z m 7.59258,-1.14363 c -0.98002,-2.4018 -1.06009,2.87087 0,0 z m 26.68898,-2.2217 c -0.72274,-2.19712 -0.83313,2.42068 0,0 z m -26.91908,-1.07805 c -0.2471,-3.27371 -1.72443,2.20491 0,0 z m 19.82114,-0.74094 c -1.68805,-1.8204 -0.29675,2.29424 0,0 z m -12.91878,-1.51352 c 0.46145,-8.18033 -2.86829,5.66177 0,0 z m -28.17496,-1.0067 c -1.77336,-2.91995 -0.9959,3.68341 0,0 z m -0.97022,-9.12977 -0.0222,1.35517 0.0222,-1.35517 z m -194.1762,26.66025 c -3.9507,-15.74735 2.71321,-64.55287 24.25363,-51.77042 -3.80982,14.80593 -23.56986,28.30695 -1.05171,18.30207 13.17105,10.14413 -16.73313,27.84951 -23.20192,33.46835 z m 16.33616,-29.41883 c -1.97798,0.18178 2.73536,2.04065 0,0 z m -21.00463,27.9138 c -7.99779,-11.50508 7.19592,-4.0582 0,0 z m 19.1947,-5.42011 c -1.98724,-3.31999 4.37019,1.01029 0,0 z m 88.39691,-5.29413 c -14.15447,-8.79607 -64.42962,-4.90956 -49.85858,-27.17505 16.11603,-0.66281 71.79617,2.50712 49.85858,27.17505 z m -20.86925,-11.00236 c -1.86465,-2.97241 -0.10993,4.28688 0,0 z m -29.91001,-7.77591 c -2.42719,-6.16285 -0.31809,7.18464 0,0 z m 29.4964,-0.36285 c -2.63299,0.10916 4.07326,5.15262 0,0 z m -7.20879,-2.43967 c -1.88927,-2.46544 -0.55642,3.22882 0,0 z m -15.38534,0.0582 c -1.02164,-2.45298 -1.02165,2.45297 0,0 z m -6.90227,-1.35332 c 0.26848,-6.63557 -2.73146,3.14279 0,0 z m 7.60496,-0.33728 c 2.47684,-6.92776 -4.71026,1.17827 0,0 z m 7.5801,-0.53108 c -0.83313,-2.42067 -0.72273,2.19712 0,0 z m -73.85479,18.32892 c 0.72274,-2.19713 0.83314,2.42067 0,0 z m 0.88416,-2.47559 c -1.78354,-7.27889 3.56864,4.63035 0,0 z m 249.76958,-3.05044 c -13.61827,-11.56975 -61.85415,-7.21837 -48.72966,-33.29579 14.96421,9.42367 59.57321,4.61137 48.72966,33.29579 z m -21.01772,-11.729 c 0.0685,-3.1332 -1.86881,3.11526 0,0 z m -0.47908,-4.86928 c -1.66328,-2.77418 -0.69008,3.58772 0,0 z m -20.93703,-0.0925 c -1.02164,-2.45298 -1.02165,2.45297 0,0 z m 21.16012,-2.91597 c 1.94379,-5.59587 -3.07037,0.98126 0,0 z m -21.04395,-4.04881 c -1.44905,-4.22044 -0.68409,5.7206 0,0 z m -6.78835,-4.88422 c -1.5077,-7.31993 -0.88218,8.48906 0,0 z m -199.01689,27.40081 c 0.83313,-2.42068 0.72273,2.19713 0,0 z m 125.41178,-6.07127 c -0.0268,-3.24316 1.85187,2.32378 0,0 z m 41.62438,-3.37091 c 1.02165,-2.45297 1.02165,2.45297 0,0 z m -147.24955,-0.55542 c 1.02157,-2.45273 1.02157,2.45273 0,0 z m 88.80984,-1.38855 c 1.11116,-3.02317 1.11116,3.02318 0,0 z m -4.60155,-1.82422 c -15.54158,-12.33085 -56.73447,0.7834 -50.96201,-30.42453 12.41412,10.02711 79.96273,1.53791 50.96201,30.42453 z m 3.68124,-10.42784 c -1.60271,-2.06688 0.12883,3.01737 0,0 z m -7.76643,-2.28611 c -2.15115,-1.25743 2.92565,4.65995 0,0 z m -44.23102,-7.9564 c -1.02164,-2.45298 -1.02165,2.45297 0,0 z m 22.40172,-1.21499 -0.0846,1.00342 0.0846,-1.00342 z m -77.84783,17.3271 c -3.61017,-10.25672 5.17196,0.39009 0,0 z m 3.90877,-5.52633 c -15.04268,-21.20688 41.49685,-48.80853 16.36488,-15.69984 -4.97285,5.63118 -9.0161,12.79136 -16.36488,15.69984 z m 147.52024,-2.73045 c -3.52708,-6.70356 4.76068,0.70348 0,0 z m 6.66791,-4.29138 c 1.31853,-0.8348 -0.86346,2.74735 0,0 z m -21.4862,-3.66232 c 1.5994,-7.74522 2.55966,6.38486 0,0 z m 123.59911,0.66532 c 3.15156,-7.28024 4.71392,3.74218 0,0 z m -2.78102,-1.48011 c -3.59547,-7.20658 4.86417,4.82136 0,0 z m 6.791,-3.26996 c 1.77163,-4.66358 4.75607,4.52103 0,0 z m -154.01532,-0.11109 c -14.25336,-9.40152 -58.57604,-4.15509 -53.22109,-22.10533 17.89397,-0.37918 60.35506,-9.53818 53.22109,22.10533 z m -24.38817,-7.64737 c -1.53251,-3.67946 -1.53251,3.67944 0,0 z m 14.26477,-4.72109 c -1.02165,-2.45297 -1.02164,2.45298 0,0 z m 7.56641,-2.36054 c -0.79273,-6.60569 -1.43137,5.04541 0,0 z m -21.96563,-4.99879 c 4.60711,-6.20754 -5.3662,-1.41511 0,0 z m 172.48203,19.617 c 1.28978,-4.00711 2.92533,4.39092 0,0 z m 9.9463,-1.70465 c 0.3929,-2.56816 0.39291,2.56815 0,0 z m -19.59702,-0.49248 c -1.45168,-8.88017 6.47255,0.74625 0,0 z m 8.56724,-0.47313 c 0.41392,-5.76235 2.60486,2.7598 0,0 z m 4.6248,0.28983 c -11.3345,-9.56749 9.50098,-9.07352 0,0 z m -8.31227,-2.22896 c -5.54231,-8.31493 5.31223,-0.54139 0,0 z m -18.02634,0.31749 c -20.2589,-3.60024 16.77609,-4.85321 0,0 z M 629.20992,418.445 c -14.14234,-25.66224 36.27541,-11.16826 0,0 z m 149.15325,2.12843 c -7.73962,1.08371 3.26214,-4.41511 0,0 z m 114.01189,-2.11718 c -15.24024,-9.35374 3.98664,-13.23544 0,0 z m -3.68456,-9.69068 c 2.21478,-7.30365 -4.93254,3.70087 0,0 z m -19.2371,9.66976 c 0.74846,-3.09893 1.1119,3.69435 0,0 z m 3.98604,-0.82538 c 2.63439,-4.6187 -0.5906,5.78359 0,0 z m -27.4409,0.73281 c -1.45123,-4.09297 3.42799,1.64859 0,0 z m 13.53412,-1.61997 c 1.31853,-0.8348 -0.86346,2.74735 0,0 z m 22.81807,0.50912 c -2.33296,-2.17517 2.25278,-0.0595 0,0 z m -246.48948,-0.98548 c 1.06459,-7.07007 3.10652,5.67392 0,0 z m 127.00264,-0.3105 c 0.83313,-2.42069 0.72274,2.19712 0,0 z m 102.78929,-0.62911 c -3.04398,-10.79529 7.99524,-1.50028 0,0 z m 2.12602,-1.28209 c -0.4017,-2.41197 -1.53489,1.43588 0,0 z m 3.12283,1.32976 c 1.11351,-4.97318 3.20816,5.71 0,0 z m -21.72946,0.0838 c -1.15306,-7.64996 5.23468,2.56848 0,0 z m 8.02302,-0.61328 c 0.83314,-2.42067 0.72273,2.19713 0,0 z m -2.99974,-0.57253 c -1.05025,-4.95229 4.26822,0.77508 0,0 z m 20.59307,-0.53701 c -14.56496,-3.78583 5.53249,-3.57464 0,0 z m 7.56181,0.18384 c -2.28544,-7.13126 6.06705,0.89529 0,0 z m -29.29649,-2.89668 c 4.90707,-14.62187 44.68368,0.60694 0,0 z m -7.24742,-0.43341 c -3.47885,-10.24907 7.52596,1.42295 0,0 z m 47.85601,0 c -6.3416,-3.0903 3.38165,-1.51005 0,0 z M 623.0582,409.51918 c 1.16122,-3.88626 1.55036,3.56598 0,0 z m 257.37985,-0.23932 c -7.2534,-8.32024 4.86044,-3.70318 0,0 z m -255.08151,-1.174 c 2.75568,1.40788 -0.0205,-2.50484 0,0 z m 216.59236,-2.65921 c -4.07301,-13.30302 5.87381,6.61185 0,0 z m 8.57118,-0.30631 c -0.47338,-5.98724 5.17661,1.37642 0,0 z m 43.23891,0.20555 c -0.77853,-2.93355 1.58433,2.08217 0,0 z m -8.49391,-0.47305 c 1.33249,-6.30079 6.93833,3.35621 0,0 z m -264.33922,-1.11789 c 0.33923,-3.62966 2.22722,2.61267 0,0 z m 3.20147,-0.0384 c 1.02165,-2.45297 1.02164,2.45298 0,0 z m 258.37683,-0.31049 c 1.60271,-2.06688 -0.12883,3.01737 0,0 z m 8.74289,0.33714 c -1.94068,-4.29045 9.05347,4.13557 0,0 z m -218.1133,-0.61485 c 1.5349,-1.43589 0.40169,2.41202 0,0 z m 45.09517,0.36992 1.09896,-0.37258 -1.09896,0.37258 z m 17.25579,-0.33713 c 0.72273,-2.19713 0.83313,2.42067 0,0 z m 76.06935,0.176 0.83116,0.10256 -0.83116,-0.10256 z m 16.45677,-0.24437 1.81274,0.25812 -1.81274,-0.25812 z m 16.07042,0.0684 c 0.83313,-2.42068 0.72272,2.19713 0,0 z m 1.88797,0.0925 c 0.91171,-2.0937 0.91167,2.09365 0,0 z m 1.56317,-0.0925 c 1.2801,-2.76731 1.2362,2.56086 0,0 z m 24.84835,0 c 0.83314,-2.42068 0.72274,2.19713 0,0 z m 6.44217,0 c 0.83314,-2.42068 0.72273,2.19713 0,0 z"
+       id="path3571"
+       inkscape:connector-curvature="0"
+       inkscape:export-filename="/home/cats/Desktop/pyohio.png"
+       inkscape:export-xdpi="71.95591"
+       inkscape:export-ydpi="71.95591" />
+    <path
+       style="fill:#510404;opacity:0.75"
+       d="m 167.96397,969.24672 c 2.36736,-3.03526 6.23586,0.91948 0,0 z m 8.01389,-0.6118 c 0.50512,-4.27838 0.89542,3.10033 0,0 z m 1.54616,0.56595 c 0.6308,-2.19306 1.07549,2.23977 0,0 z m 2.15632,0 c 1.15641,-2.2715 1.15641,2.27149 0,0 z m 3.11459,0 c 1.07558,-2.23987 0.63089,2.19316 0,0 z m 3.11503,-0.14456 c 4.19177,-2.33225 1.34412,2.10828 0,0 z m 2.87471,0.14456 c 1.76459,-2.49161 2.31316,2.57639 0,0 z m 23.47965,-0.0663 c 5.82321,-24.63859 18.60768,6.81086 0,0 z m 12.219,0.0663 c 1.51243,-2.51996 0.73744,2.38838 0,0 z m 27.23492,-0.15408 c 11.54165,-19.97958 48.29987,-13.99311 48.51473,0.0212 -15.8121,-0.41976 -32.45243,0.16926 -48.51473,-0.0212 z m 24.27664,-0.67937 c -1.86704,-2.51487 -1.11777,1.53137 0,0 z m -3.36158,-0.75704 c -0.60972,-5.44942 -2.90685,1.56627 0,0 z m 24.33706,-2.56149 c -2.86331,-6.70491 -2.46473,3.03815 0,0 z m -27.07808,-1.39923 c 0.86827,-5.70127 -2.90329,1.33137 0,0 z m 19.51956,-1.6786 c -1.14588,-3.19631 -1.14598,3.19625 0,0 z m 199.09332,7.22039 c 11.75856,-11.59598 62.35154,-0.47358 26.51324,-0.11217 -8.78924,-0.82932 -18.02049,0.11669 -26.51324,0.11217 z m 46.85356,0.18695 1.41425,0.0394 -1.41425,-0.0394 z m 7.05873,-0.21165 c 1.42744,-1.2831 0.88075,2.19373 0,0 z m 2.18009,-2.53881 c 3.69456,-23.91061 -15.91864,-56.70272 3.96132,-61.58411 21.75766,8.44937 -3.15936,-26.73437 -3.49607,-11.93023 -9.52267,-14.85537 -0.24282,-22.66753 7.56047,-7.35038 7.72755,-3.60017 -22.49549,-24.85149 -1.93104,-29.55782 16.1701,-0.48312 7.39011,-7.77827 9.41185,-21.60556 16.10935,3.84644 9.40245,-22.79254 24.67825,-25.56471 -18.9501,-16.70553 6.2383,-9.36542 18.4269,-9.41581 -3.5225,27.37394 22.8221,16.20183 29.6527,32.24205 17.8431,-1.35416 -9.5501,-37.45558 16.2157,-27.68127 15.9855,11.37076 24.8315,2.71797 24.157,-16.9463 6.3354,-4.68781 36.8168,2.37437 12.6966,-7.19297 -25.3413,1.07583 -8.6422,-33.15601 10.5086,-20.23236 26.243,-2.89863 3.8395,34.97776 8.2709,28.53274 12.6269,11.37595 7.4157,31.54812 16.0587,6.96606 18.9683,-2.97373 -1.081,-36.27407 24.0718,-38.54375 -30.8352,-3.48331 -3.2472,-37.00764 17.2388,-25.76578 20.3439,-5.14721 56.5588,-3.74386 43.6985,26.61696 8.7257,31.16725 37.4041,2.86971 23.3487,-19.29056 15.5317,-14.26897 49.4064,-9.42281 63.9479,-2.64178 6.3986,25.98688 -57.275,4.23158 -48.7874,20.94385 12.2731,-4.4663 6.719,30.40151 21.3314,8.86362 -3.1785,-27.35656 54.5041,0.57132 19.5006,11.2311 -5.3376,1.56301 24.0242,19.82562 13.4033,-8.69988 -1.4778,-35.19422 13.8046,-77.21437 8.394,-100.00779 1.2941,-21.63739 3.2175,-39.17826 3.032,-7.09031 0.1453,101.74669 1.2548,204.20971 -0.3244,305.52169 -28.6772,8.71669 -63.9322,0.31787 -95.1019,3.28729 -89.7665,0.53894 -180.11,-0.30278 -269.51726,-0.25539 l -0.40792,-2.8486 0,0 z m 4.768,-0.88949 c -2.65298,-5.0895 -3.33372,5.87136 0,0 z m 5.51052,-23.97313 c -0.3336,-11.83553 -4.0829,3.22718 0,0 z m -3.83341,-1.79095 c -0.55649,-10.32041 -7.01352,0.82088 0,0 z m -4.55216,-7.21163 c -1.23936,-2.35868 -1.64453,2.40601 0,0 z m 2.39583,-0.57839 c -0.6308,-2.19302 -1.07549,2.2398 0,0 z m -7.33937,-11.69297 c -1.95,-0.65679 1.94056,2.57864 0,0 z m 8.53734,-10.86394 c -1.7329,-2.43777 -1.7329,2.43776 0,0 z m 7.09585,-1.77853 c -1.51332,-2.52885 -1.51323,2.52885 0,0 z m 80.59358,-13.87194 c -1.5652,-2.21177 -0.7055,3.10367 0,0 z m -3.1895,-1.82034 c 0.6988,-5.30029 -2.4025,4.47826 0,0 z m 3.08,-2.73094 c -3.986,-10.32277 -6.6599,4.52041 0,0 z m -86.62157,-0.60188 c -2.10105,-3.27843 -1.34457,4.10885 0,0 z m 80.50177,-1.77144 c -2.2885,-8.07153 -3.199,6.36475 0,0 z m -72.85238,-0.24572 c 1.1491,-5.09776 -3.45389,3.16473 0,0 z m 53.72308,-9.25723 c -1.3829,-25.29211 -14.3779,7.03822 0,0 z m 9.0666,2.69105 c -1.1774,-8.32563 -3.7756,3.23715 0,0 z m -38.262,-15.87148 c 8.9118,-15.03694 -6.4368,3.28704 0,0 z m -10.6141,-2.2898 c 10.393,0.61493 -8.6196,-1.82039 0,0 z m 1.6666,-5.47308 c 5.2937,-18.03276 -7.2923,-8.97049 0,0 z m -5.5,0.3885 c -1.1565,-2.27147 -1.1565,2.27149 0,0 z m 52.4699,-6.6514 c -4.9978,-7.60228 -4.1453,6.05307 0,0 z m -40.4905,-4.85436 c -2.3234,-3.34241 -2.1254,2.58118 0,0 z m 50.3136,-2.95379 c -1.0755,-2.23978 -0.6308,2.19304 0,0 z m -63.7305,-2.31352 c -1.7331,-2.4379 -1.7331,2.43788 0,0 z m 62.293,-0.25507 c -0.8807,-2.19369 -1.4274,1.28306 0,0 z m 3.3469,-0.75711 c -0.4771,-4.70143 -2.5396,1.6597 0,0 z m 3.122,-3.03651 c -2.8094,-0.95746 0.5293,3.76282 0,0 z m -22.4528,-1.73515 c -6.6405,-14.24304 -11.7648,6.62296 0,0 z m -38.6423,-1.06037 c -1.2592,-4.00993 -1.3335,1.99377 0,0 z m 69.9599,-3.51848 c 6.0108,-13.90567 -3.8671,1.64227 0,0 z m 11.9794,-0.0824 c -1.5651,-2.21166 -0.7055,3.10354 0,0 z m -49.6006,-2.86913 c -2.6284,-0.32946 0.6164,3.52637 0,0 z m 46.7182,-0.16737 c -2.5479,-0.33339 0.5927,4.03683 0,0 z m -3.5365,-0.24301 c -2.2058,-0.13954 1.1195,2.73068 0,0 z m 247.5409,-1.42909 c -3.606,-1.84837 0.5793,2.66738 0,0 z m -271.7894,-0.78603 c -1.5652,-2.21181 -0.7055,3.1037 0,0 z m -11.9793,-2.60272 c -1.5652,-2.21169 -0.7056,3.10354 0,0 z m 54.2575,-1.64426 c 1.017,-17.30148 -2.503,7.18795 0,0 z m 59.7866,1.67838 c -1.6445,-2.40599 -1.2394,2.3587 0,0 z m 174.1112,-0.85681 c -3.447,-6.93757 -5.0006,5.10113 0,0 z m -188.0073,-1.45668 c 9.3013,-8.30097 -5.2868,-0.2875 0,0 z m 14.3753,-1.41182 c -0.8807,-2.1937 -1.4274,1.28306 0,0 z m -58.4596,-0.90172 c -1.1563,-2.27124 -1.1563,2.27124 0,0 z m 229.0467,-0.90171 c -1.6003,-3.16327 -0.6449,4.11299 0,0 z m -189.7542,-1.12262 c -1.1459,-3.19615 -1.1459,3.19611 0,0 z m -45.0427,-0.2892 c -1.6445,-2.40599 -1.2393,2.3587 0,0 z m 8.146,-4.15749 c -9.2356,-8.77846 -4.8031,7.24543 0,0 z m 2.3959,1.84392 c -2.3078,-2.53077 -2.3078,2.53076 0,0 z m 45.2822,-0.57838 c -0.6308,-2.19304 -1.0754,2.23978 0,0 z m 178.125,-2.79846 c -3.5175,0.67836 3.5117,4.48099 0,0 z m -223.4072,0.80825 c -1.2682,-4.50708 -2.1402,3.14108 0,0 z m 218.9794,-0.60566 c -0.2528,-6.54761 -3.9535,4.96686 0,0 z m 2.8797,-1.4528 c -1.0695,-4.04287 -1.2986,4.2064 0,0 z m -176.8164,0 c -1.2393,-2.3587 -1.6445,2.40599 0,0 z m -69.2616,-0.53841 c -0.045,-2.94665 -1.5804,1.98516 0,0 z m -64.9081,-1.53413 c -1.7244,-2.78934 -1.4561,3.40242 0,0 z m 284.6314,0.33738 c -1.1564,-2.27123 -1.1564,2.27126 0,0 z m 20.1254,-0.90171 c -1.512,-2.12338 -0.169,2.95426 0,0 z m 4.1405,0.0353 c 18.9694,-1.78033 -8.8585,-6.15276 0,0 z m -173.5146,-1.28068 1.3675,-1.44845 -1.3675,1.44845 z m 169.1779,-1.17434 c -3.4099,0.38432 0.074,2.23545 0,0 z m 5.6383,-2.17319 c 11.1115,-10.52257 -5.9388,-15.2908 0,0 z m -166.9248,-0.83344 c -1.7009,-4.62189 -1.4938,2.22874 0,0 z m -5.1157,-0.84515 c -0.4055,-5.19016 -2.1289,3.13186 0,0 z m 97.1177,0.26677 c -1.7009,-4.62201 -1.4937,2.22874 0,0 z m 6.4346,-1.3864 c -0.4098,-8.63427 -4.2281,6.20406 0,0 z m -100.8325,-0.34875 c -0.7056,-3.10354 -1.5651,2.21168 0,0 z m 98.1883,-3.54676 c 1.0005,-6.68264 -6.5327,5.0936 0,0 z m -86.2162,-3.28337 c -0.4758,-4.70113 -2.5416,1.66062 0,0 z m 89.1343,-0.39965 c -1.4161,-6.42859 -1.8337,4.81328 0,0 z m -17.2504,-3.14442 c -1.1066,-3.99951 -3.6742,0.86783 0,0 z m -42.9527,-0.9384 c -1.8622,-3.44257 -0.3032,3.05134 0,0 z m -3.5275,-0.57838 c -1.146,-3.19628 -1.1459,3.19631 0,0 z m 28.4268,0.0566 c 0.1534,-4.2043 -1.9401,3.04279 0,0 z m 28.6692,-2.22297 c -2.7302,-1.51056 -0.3421,3.25724 0,0 z m -7.9124,-0.67729 c -4.8641,-6.54525 0.9283,4.7169 0,0 z m 10.474,0.81937 c -0.7375,-2.38843 -1.5125,2.5199 0,0 z m 3.2879,-0.28921 c -2.4953,-3.84376 -2.8854,3.44572 0,0 z m 2.2226,-0.28918 c -1.1564,-2.27149 -1.1564,2.27148 0,0 z m 34.5008,-1.48836 c -2.1512,-3.07998 -2.1563,3.61452 0,0 z m 6.6301,-1.55174 c -10.4586,-9.27238 -3.1572,5.61275 0,0 z m 28.829,1.54594 c -1.6802,-2.78179 -1.4517,3.39529 0,0 z m -22.6352,-1.85308 c -4.7666,-6.97776 -4.2632,7.13575 0,0 z m 2.879,1.14215 c -1.1804,-2.72055 -1.2439,3.48715 0,0 z m -61.7958,-0.15183 c -1.5133,-2.52892 -1.5132,2.52894 0,0 z m -87.1184,-1.51825 c -2.0141,-3.38244 0.1942,5.00761 0,0 z m 97.273,0.69406 c 4.1591,-4.9942 -9.2174,0.17758 0,0 z m 32.1049,0.21314 c -3.3316,-4.3031 -3.2541,2.83094 0,0 z m -45.8013,-1.28976 c 1.0816,-12.50152 -6.3107,6.27421 0,0 z m 8.5505,-0.14889 c 8.3629,-9.63174 -6.6597,1.66024 0,0 z m 40.1258,-0.14963 c -1.6992,-5.01163 -2.7962,2.77908 0,0 z m 6.9157,-0.007 c -3.0649,-8.7014 -3.5516,1.94591 0,0 z m -52.4375,-2.84461 c -1.4762,-7.87574 -3.1089,1.37132 0,0 z m -129.5298,-1.37576 -0.088,1.04498 0.088,-1.04498 z m 123.4588,-0.71228 c -0.2835,-8.68279 -4.1484,2.94692 0,0 z m 16.7802,-0.64376 c -1.9253,-3.16915 -0.036,4.48076 0,0 z m 32.4167,0.59691 c -1.1459,-3.19632 -1.146,3.1963 0,0 z m -150.7415,-1.2383 c 0,-2.61938 -1.7203,4.0824 0,0 z m 119.8346,-1.94254 c 0.9854,-3.67551 -3.1448,2.27577 0,0 z m -79.3877,-10.541 c 14.6532,-3.11634 -11.0483,-5.67982 0,0 z m 1.761,-1.60503 c 1.0755,-2.23979 0.6308,2.19317 0,0 z m 9.1312,-0.89861 -1.3764,-0.14889 1.3764,0.14889 z m 6.4421,1.80032 c -1.1272,-6.33968 -1.2707,4.92589 0,0 z m 5.6402,-0.21488 c -1.6684,-2.7835 -1.4946,3.35542 0,0 z m -16.1822,-1.01016 c 10.4241,-11.10827 -8.1891,2.36736 0,0 z m 24.1022,0.12834 c 13.4162,-1.1689 -3.5396,-3.16634 0,0 z m 15.1904,-0.11235 c -2.1716,-6.60601 -2.5691,4.40395 0,0 z m -18.2087,-0.27104 c -1.0755,-2.2398 -0.6308,2.19302 0,0 z m 12.4945,-0.15906 c -1.9423,-1.36976 -0.2345,2.14191 0,0 z m -14.1716,-3.04904 c -5.085,-6.59782 -5.339,7.00923 0,0 z m 18.2087,0.89456 c -3.7084,-7.40613 -5.1874,2.55184 0,0 z m 6.4189,0.0495 c 0.3112,-7.46104 -9.2238,2.51586 0,0 z m -36.3675,-0.62789 c -0.6308,-2.19303 -1.0755,2.23979 0,0 z m 6.7085,0 c -1.1563,-2.27124 -1.1563,2.27125 0,0 z m 10.3023,-0.57838 c -0.6308,-2.19303 -1.0755,2.23979 0,0 z m 5.9897,-0.57839 c -1.2393,-2.35868 -1.6445,2.40601 0,0 z m 20.772,-11.87535 c -1.8709,-3.18608 -0.1327,4.15052 0,0 z m 73.5341,-0.89244 c -1.5134,-2.52908 -1.5134,2.52908 0,0 z m 0.1574,-5.54435 c -3.6552,-3.8199 0.1771,8.91592 0,0 z m 6.7816,2.11685 c -2.3161,-4.18022 -0.3324,4.929 0,0 z m -105.5577,-4.62648 c -1.1564,-2.27148 -1.1564,2.27149 0,0 z m -9.344,-1.15677 c -0.6308,-2.19303 -1.0755,2.2398 0,0 z m -492.98355,227.5087 c -1.34758,-3.49491 4.25016,0.83892 0,0 z m -6.07954,-5.41029 c 1.1563,-2.27124 1.1563,2.27125 0,0 z m 262.46934,-22.36159 1.16913,0.0276 -1.16913,-0.0276 z m -1.71226,-12.08273 c 1.42735,-3.67405 1.6002,3.42976 0,0 z m -3.22513,-0.30903 c -0.41496,-4.04733 2.04034,2.2205 0,0 z m 12.81358,-17.73487 c 2.74218,-4.98076 1.83892,3.88513 0,0 z m -2.5023,-2.42011 c 0.71821,-10.71315 1.65075,3.94078 0,0 z m 5.83887,-0.009 c 0.67861,-2.66118 0.79067,1.87952 0,0 z m -386.76789,-3.78806 c 1.37438,-5.17409 0.90761,5.04839 0,0 z m 28.4919,-0.32653 c -1.01701,-19.46661 3.14564,-63.58791 6.86051,-23.68166 12.24739,-7.74502 16.56697,13.72236 -1.65584,18.83614 l -5.20467,4.84552 z m 2.69055,-11.11098 c -1.94218,-1.36961 -0.23445,2.14183 0,0 z m 0.92239,-11.75967 c -2.0966,-4.52225 -2.49197,4.44124 0,0 z m -50.18435,21.1328 c -0.0896,-3.65979 1.27896,3.06902 0,0 z m 10.65228,0.0401 c 1.64452,-2.40601 1.23935,2.35868 0,0 z m 7.54045,-0.67308 c -1.24594,-8.02995 4.85443,3.10891 0,0 z m -18.32197,-3.3756 c 0.37918,-4.0385 1.04603,4.12452 0,0 z m 51.84703,-19.20256 c -2.96034,-10.58482 3.91575,0.41173 0,0 z m 14.71471,0.54946 c -2.43928,-6.14495 5.80923,-2.75112 0,0 z m -3.78953,-3.90409 c 1.73299,-2.43768 1.73299,2.4377 0,0 z m -6.85518,-1.52663 c -0.009,-3.59353 4.06583,1.02946 0,0 z m 7.90939,-0.90257 c -15.46861,-5.63156 5.26103,-17.43272 2.10897,-17.58258 0.94874,4.56628 3.53444,16.2586 -2.10897,17.58258 z m -2.01257,-7.11411 c -1.11475,-3.02893 -1.10629,3.2812 0,0 z m 2.87506,-1.44596 c -1.7329,-2.43776 -1.7329,2.43777 0,0 z m 0.47923,-4.30374 c -0.88083,-2.19372 -1.42743,1.2831 0,0 z m -0.95836,-2.97423 c -1.68022,-2.78179 -1.45173,3.39529 0,0 z m 3.3542,8.1659 c 2.05378,-3.28436 2.58632,1.71464 0,0 z m 299.60557,-7.63319 c -6.75387,-22.23142 14.71062,-1.91746 0,0 z m -25.03703,-0.7737 c 1.15631,-2.27125 1.15631,2.27124 0,0 z m -294.21477,-1.15678 c -8.09319,-22.47277 22.0767,-36.53285 14.00505,-12.03963 18.36129,-6.02133 -16.49756,6.27223 -14.00505,12.03963 z m 10.17519,-16.426 c 2.34493,-20.48263 -14.1059,7.88145 0,0 z m -7.30013,15.74926 c 1.665,-3.19466 3.12731,1.73457 0,0 z m 298.84687,0.29116 c -2.06802,-9.36605 6.77925,-0.49433 0,0 z m 9.34412,-0.69827 c -4.02684,-16.53281 13.27108,3.58759 0,0 z m -298.5154,-2.0924 c 0.59484,-6.8027 2.33104,9.37533 0,0 z m 282.62248,1.60916 c -8.09747,-5.93144 8.46195,-2.57015 0,0 z m -274.08933,-1.32531 c 1.12961,-4.13482 1.12971,4.13478 0,0 z m -50.31358,-2.31353 c 1.15639,-2.27148 1.15639,2.27147 0,0 z m 45.76142,-0.57838 c -0.166,-5.64861 4.39578,3.0326 0,0 z m 3.33719,-0.14461 c -1.17018,-7.33653 3.81697,1.26937 0,0 z m 342.047,-1.96665 c -0.94866,-7.1696 5.36792,2.31408 0,0 z m -346.08042,-7.72127 c 0.38541,-5.13209 2.20537,0.0657 0,0 z m 296.27951,-2.42792 c -3.06759,-18.10978 8.8179,5.29988 0,0 z m 24.50708,1.84955 c 0.73726,-2.38853 1.51261,2.5199 0,0 z m -17.21043,-0.95037 c -0.6097,-3.82652 2.04418,3.66687 0,0 z m -24.1538,-1.17064 c 1.44435,-4.32177 1.77146,3.7145 0,0 z m 32.92186,0.0229 c -3.95608,-18.65597 16.0639,-0.54836 0,0 z m 7.06914,-0.93841 c 1.46571,-10.65522 10.42184,3.85965 0,0 z m -316.02346,-0.30247 c -0.22983,-4.7191 3.21499,2.37668 0,0 z m -20.8976,-0.70026 c -0.46018,-5.45632 2.46998,1.42583 0,0 z m 320.80429,-0.29863 c 1.23989,-2.87449 1.23989,2.87447 0,0 z m -318.28233,-0.72299 c -5.54594,-10.39268 6.49638,4.51881 0,0 z m 440.08931,-0.75252 c -1.8552,-5.02031 3.7339,2.49965 0,0 z m -144.32828,-0.19138 c 0.18772,-3.92702 1.98454,2.0724 0,0 z m 25.21247,-0.62529 c -7.57417,-6.60412 5.8403,1.24448 0,0 z m -349.37586,-0.31055 c -0.20356,-5.60044 3.65826,1.92192 0,0 z m 47.19892,-2.02434 c 1.14589,-3.19611 1.14589,3.19615 0,0 z m 317.32513,-0.97602 c 1.49463,-3.35541 1.66847,2.78345 0,0 z m -338.61419,-0.4029 c 3.32945,-19.21337 -7.0607,-45.82797 17.1466,-35.58663 4.69645,-29.0428 -30.2937,4.70217 -16.2786,-27.64852 -10.43019,-7.37331 -10.65476,-17.69345 -15.52113,2.41688 17.42031,-2.65757 -7.84761,29.22161 -7.15254,1.32805 -23.93146,5.75735 11.1922,-12.11708 1.62574,-13.52669 -20.89244,6.93074 -10.76265,-38.53589 7.68562,-28.64724 -19.99906,-3.52764 -43.18561,0.8573 -33.57945,-34.79349 4.13133,-22.72304 -12.97993,-69.99174 20.89244,-59.51565 -4.97744,-15.2783 31.20372,2.22313 17.42458,22.57793 4.17468,25.02048 -6.84173,73.0663 28.80752,61.08298 18.50497,3.95261 11.14325,29.39676 25.95089,35.68614 -9.39219,4.9143 -28.06244,4.9866 -21.24412,30.22536 -8.41629,14.30394 1.06063,54.72201 -14.17007,41.05287 -2.42753,5.05247 -8.09951,2.61285 -11.58748,5.34801 z m 2.60118,-4.6941 c -1.73308,-2.43788 -1.73308,2.4379 0,0 z m 6.22926,-3.82774 c -1.98453,-2.0724 -0.18772,3.92701 0,0 z m 11.50026,-0.22094 c -1.07549,-2.23978 -0.6308,2.19304 0,0 z m -9.59396,-2.51849 c 26.59851,-20.64565 -24.1781,-21.50654 0,0 z m 0.0107,-2.72108 c 1.42752,-1.28318 0.88074,2.19393 0,0 z m 7.39154,-14.75416 c 11.95909,-2.77909 -6.18209,-0.56926 0,0 z m -7.48339,-3.76333 c -1.51324,-2.52885 -1.51333,2.52885 0,0 z m 10.63367,-3.97116 c -1.27176,-4.17748 -2.78223,3.10858 0,0 z m -19.40665,-12.75858 c -0.63081,-2.19304 -1.07549,2.23978 0,0 z m 22.28168,-1.15678 c -1.73291,-2.43775 -1.73291,2.43776 0,0 z m -9.2722,-4.31083 c 8.95133,-31.12867 -31.03309,-4.73528 0,0 z m -28.78723,-0.8946 c 1.20331,-4.19651 -8.40009,5.07706 0,0 z m -11.2958,-1.75548 c -3.29287,-3.24977 -2.31698,5.32756 0,0 z m 8.14606,-1.74893 c -1.56513,-2.21164 -0.70557,3.10356 0,0 z m -0.95836,-2.85779 c -1.64451,-2.40599 -1.23935,2.3587 0,0 z m 26.74404,-9.21797 c -1.77954,-2.22314 -1.11634,3.53329 0,0 z m -10.4521,-0.32533 c -3.47328,-4.65128 -2.36032,3.99775 0,0 z m -12.45852,-3.40284 -1.89837,-0.2958 1.89837,0.2958 z m 26.83385,-1.54756 c 18.95482,-23.09035 -29.46272,-9.69499 0,0 z m 20.52261,0.5562 c 1.40865,-5.20393 -4.14432,4.94667 0,0 z m -37.57424,-0.81715 c 1.7921,-13.96158 -5.9317,2.63932 0,0 z m -16.56084,-2.20572 c 0.61638,-7.09591 -4.34824,3.42236 0,0 z m 21.9609,-1.17294 c 2.35899,-19.90215 -11.64712,2.17071 0,0 z m 26.74564,0.20346 c -0.6308,-2.19303 -1.07549,2.23978 0,0 z m 13.89619,-2.89191 c -1.64452,-2.40601 -1.23935,2.35868 0,0 z m -46.38403,-1.6728 c 0.94855,-5.46937 -3.26333,3.40041 0,0 z m -24.29462,-1.21913 c -1.07549,-2.23978 -0.6308,2.19305 0,0 z m 0.86249,-1.85082 c 2.33986,-5.94616 -4.23378,1.83716 0,0 z m 22.61724,0.43901 c -0.88073,-2.19369 -1.42742,1.28305 0,0 z m 1.4375,-13.62612 c -2.81953,-6.40876 -5.79669,7.03019 0,0 z m -14.83069,-34.70297 c 13.66352,-10.46397 -14.92158,-0.29893 0,0 z m 3.33043,-9.25412 c -1.1564,-2.27148 -1.1564,2.27148 0,0 z m -3.3542,-1.15676 c -0.63089,-2.1931 -1.07567,2.23986 0,0 z m -19.22211,-2.26032 c 1.82664,-8.91939 -7.25028,2.68647 0,0 z m 20.83289,-0.34241 c -0.46711,-3.0869 -1.06578,3.164 0,0 z m -0.17836,-3.46293 c -0.16191,-8.19486 -6.86586,5.26486 0,0 z m 0.96342,-4.92362 c -1.15639,-2.27149 -1.15639,2.27148 0,0 z m 0.95836,-5.49463 c -1.73451,-3.40701 -1.73451,3.40704 0,0 z m -12.25888,-11.99218 c 1.70639,-28.14554 -18.16531,7.36978 0,0 z m 3.15455,-6.83939 c -1.60028,-3.16326 -0.64487,4.11295 0,0 z m 5.85231,-5.74969 c -0.0115,-5.91437 -1.89864,6.08918 0,0 z m 5.60291,-14.23584 c -2.55668,-2.18159 0.85929,3.82099 0,0 z m 17.29534,201.05344 c 1.15631,-2.27126 1.15631,2.27123 0,0 z m -32.10485,-2.58458 c 2.01008,-2.33919 1.45378,3.1863 0,0 z m 377.26633,-2.33427 c 1.6609,-8.31412 1.74554,6.59443 0,0 z m 68.36849,1.44854 c 1.1564,-2.27148 1.1564,2.27148 0,0 z m 23.7193,0 c 1.6445,-2.406 1.2394,2.35869 0,0 z m -63.1593,-1.11676 c 2.437,-6.13264 1.3245,3.72322 0,0 z m -403.08014,-0.61839 c -0.14348,-5.50011 2.70924,2.34329 0,0 z m 390.34694,-0.20612 c -9.80697,-12.78086 16.3703,-3.82221 0,0 z m 2.33878,-1.8182 c -1.11492,-3.029 -1.1062,3.28117 0,0 z m 65.90052,1.47254 c -23.9758,-4.82604 -11.1988,-27.08474 3.9861,-11.15422 2.1013,4.04716 0.8746,11.63205 -3.9861,11.15422 z m -6.9617,-12.46182 c -2.6392,-4.90622 -1.0482,4.04748 0,0 z m -4.7918,-0.61251 c -1.5119,-2.12333 -0.1689,2.95413 0,0 z m -50.9086,12.3546 c -1.80619,-16.15366 15.8529,2.87215 0,0 z m -84.10508,-3.16242 c -5.68934,-4.95661 8.94224,-2.09488 0,0 z m 42.77625,-0.40321 c -0.69444,-10.21455 9.48458,5.14179 0,0 z m 88.12093,-1.74249 c -0.9498,-4.0806 2.9879,1.55638 0,0 z m -139.49887,-0.80449 c -7.66204,-9.7907 7.34347,2.41641 0,0 z m 5.86557,-0.68664 c -1.07078,-8.54637 8.70681,3.28841 0,0 z m 188.7822,-1.18335 c 1.1564,-2.27148 1.1564,2.27148 0,0 z m 7.3074,-1.22154 c -7.9461,-12.61872 7.1217,-2.41874 0,0 z m -8.745,-1.51052 c -22.4603,2.70419 -28.0579,-20.66663 -11.1701,-18.22441 4.9875,13.63003 23.1605,-8.22759 11.1701,18.22441 z m -10.3986,-4.60106 c -2.0723,-3.60737 -0.7958,4.95374 0,0 z m 9.2007,-0.76424 c -1.0755,-2.23979 -0.6308,2.19303 0,0 z m -15.1206,-3.68129 c -2.1837,-7.09462 -0.2531,8.07296 0,0 z m -5.484,-0.94578 c -2.8244,-7.13303 -0.9015,6.1795 0,0 z m 5.7147,-4.28637 c 0.5777,-7.07527 -4.1908,4.87496 0,0 z m -78.0365,12.72237 c -1.9533,-3.69961 3.034,1.11161 0,0 z M 554.39701,799.732 c 3.01543,-7.1114 7.60071,4.24292 0,0 z m -394.84195,-0.57565 c 1.1564,-2.27147 1.1564,2.27149 0,0 z m 2.62263,-0.5297 c -3.12811,-7.79729 3.75287,1.27218 0,0 z m 553.10313,-1.25177 c -1.1028,-7.38099 6.7542,0.9527 0,0 z m -552.05211,-2.65279 c -0.17054,-4.14821 4.07676,2.56547 0,0 z m 8.30574,-0.19279 c 1.64453,-2.40601 1.23936,2.35868 0,0 z m 119.05587,-0.0384 c 0.14552,-3.43409 3.03705,3.11363 0,0 z m 377.8509,0.0384 c 1.0755,-2.23979 0.6308,2.19302 0,0 z m -128.33666,-0.95965 c 1.76682,-3.98389 2.00118,3.46656 0,0 z m 23.15726,-0.19712 c 1.2394,-2.35869 1.6445,2.40599 0,0 z m -403.22763,-0.47343 1.2277,-1.03681 -1.2277,1.03681 z m 558.24153,-0.97252 c 2.926,-9.25257 8.4014,-0.27846 0,0 z m -4.1756,-2.89191 c 0.5093,-4.68482 0.1991,5.74498 0,0 z m -158.98428,1.44594 c 1.07549,-2.23978 0.63081,2.19304 0,0 z m 63.82038,0.20485 c -2.7931,-9.76422 4.6542,-2.0103 0,0 z M 173.046,789.64911 c 1.13752,-3.36627 1.48902,2.78479 0,0 z m 448.71512,0.33075 c -1.4884,-2.80283 1.8669,0.57029 0,0 z m 2.466,-0.42707 c -1.9773,-2.67615 2.3147,-0.95766 0,0 z m 34.391,-0.22895 c 0.7374,-2.38841 1.5124,2.51992 0,0 z m 68.0432,-0.57838 c -12.0521,-8.73997 2.3773,-5.53885 0,0 z M 164.82597,787.8779 c -9.24754,-18.67847 2.78508,-29.08083 0,0 z m 11.02112,0.86756 c 1.23927,-2.35866 1.64443,2.40599 0,0 z m 2.24026,0.19783 c 0.30094,-5.94735 3.19853,2.08957 0,0 z m 419.95167,-0.19783 c -9.2707,-12.83075 22.3517,0.25308 0,0 z m 18.4914,0.1928 c -0.9817,-4.12479 3.3285,1.55962 0,0 z m -446.6015,-1.48417 c 0.65279,-6.38238 3.91566,5.52809 0,0 z m 125.71244,0.71298 c 1.95882,-8.9505 3.65052,1.60667 0,0 z m 243.39385,-3.61487 c -11.6481,-28.36333 36.12021,-19.86694 6.66167,0.8332 -0.76557,3.72752 -7.60098,4.05931 -6.66167,-0.8332 z m 8.41566,-5.43496 c -4.26849,-11.34269 -3.29456,10.35116 0,0 z m 5.50866,-5.37559 c -0.70558,-3.10353 -1.56513,2.21169 0,0 z m -10.18258,-3.26352 c -2.50817,-0.66636 0.032,3.10157 0,0 z m 4.91167,17.22112 c 0.81932,-7.6167 2.59771,1.17695 0,0 z m 91.5229,-0.35244 c -0.3531,-7.2445 4.0044,3.92461 0,0 z m 18.2827,-0.0774 c 1.0774,-4.53727 1.9076,3.12258 0,0 z m -36.3071,-0.51319 c -0.8188,-6.49947 2.4092,2.01465 0,0 z m 95.651,-0.0693 c 1.5651,-2.21169 0.7056,3.10358 0,0 z m -131.2945,-0.49605 c -7.12,-23.11115 21.7816,4.94326 0,0 z m 3.8334,-3.51849 c -1.1149,-3.02899 -1.1062,3.28114 0,0 z m 121.711,2.60272 c 1.1563,-2.27125 1.1563,2.27125 0,0 z m -536.7983,-0.43805 c -3.2077,-3.33539 3.62308,-0.20721 0,0 z m 2.18719,-1.1525 c -1.44816,-5.04838 3.46244,3.16923 0,0 z m 430.93451,0.14793 c 1.8472,-2.33509 0.8304,3.13536 0,0 z m 4.9734,-0.4371 c 0.6794,-3.28695 0.6813,4.86999 0,0 z m 35.931,0.14459 c 0.6233,-3.3603 0.6233,3.3603 0,0 z m 38.8133,0.28919 c 1.1459,-3.19611 1.1459,3.19613 0,0 z m -77.1475,-0.28919 c 1.1563,-2.27123 1.1563,2.27125 0,0 z m 32.584,-0.28919 c 1.1459,-3.19612 1.1459,3.19614 0,0 z m 11.307,0.37954 c -0.032,-3.09875 2.4847,0.71471 0,0 z m 3.5475,-0.0904 c 1.1563,-2.27123 1.1563,2.27125 0,0 z m 61.8139,-0.17018 c -2.7641,-3.11831 2.8596,-0.0273 0,0 z m -560.95223,-0.2126 c -0.16101,-9.61116 5.05916,0.1283 0,0 z m 11.99782,-1.17678 c 1.39592,-13.82924 9.27834,-2.61758 0,0 z m 448.80641,0.47025 c 2.7789,-3.20364 2.9966,2.51382 0,0 z m 93.4396,-0.64581 c 1.2393,-2.35858 1.6442,2.40585 0,0 z m -117.8451,-0.55409 c -1.12,-5.70458 4.8398,2.62434 0,0 z m 17.4597,-0.20778 c -0.579,-5.8481 2.0753,1.71646 0,0 z m 110.7237,-0.32441 c 1.6792,-9.27306 6.0977,-0.73986 0,0 z m -447.58761,-0.64888 c 1.07549,-2.23978 0.63081,2.19304 0,0 z m 6.48632,-0.26385 c -1.1491,-5.09777 3.45389,3.16472 0,0 z m -4.60201,-0.49715 c 0.47949,-8.75888 5.86442,1.00026 0,0 z m 298.3202,0.18262 c 1.0757,-2.23987 0.6309,2.1931 0,0 z m -21.85604,-0.68289 c 0.86384,-7.08884 6.13207,-3.0204 0,0 z m -284.81734,-0.47388 c 1.1564,-2.27147 1.1564,2.27149 0,0 z m 304.27758,0 c 1.6445,-2.40599 1.2393,2.3587 0,0 z m -387.08543,-0.61453 c 1.11644,-3.53339 1.77946,2.22316 0,0 z m -6.9181,-0.92528 1.16913,0.0276 -1.16913,-0.0276 z m 378.69181,-0.82325 c 2.10825,-3.69433 -0.72472,4.06402 0,0 z m -402.05165,0.0495 c 1.23927,-2.35867 1.64443,2.40597 0,0 z m 13.51675,0.18728 c -2.95259,-8.33097 5.21403,1.17622 0,0 z m 105.31917,-0.40996 c 3.32678,-8.13556 3.64739,1.70616 0,0 z m -97.51259,-0.35572 c 1.07567,-2.23985 0.63089,2.1931 0,0 z m 44.62977,-0.28918 c 1.07522,-3.17951 0.45261,3.09701 0,0 z m 439.06047,-1.15677 c -2.8168,-21.23092 3.501,1.11531 0,0 z m -3.2253,-1.48533 c 1.1833,-9.45793 1.4471,7.88097 0,0 z m -481.66282,1.21428 1.42173,0.3222 -1.42173,-0.3222 z m 103.02302,-1.17492 2.66251,-4.28006 -2.66251,4.28006 z m -100.55311,0.25914 c 1.07735,-4.53721 1.90771,3.12264 0,0 z m 469.85901,0.53617 c -0.8985,-5.42081 2.5245,0.45743 0,0 z m 6.8807,-1.40261 c 0.052,-5.18039 1.3889,4.76868 0,0 z m -489.43545,0.7519 c -2.04898,-12.5744 8.11081,1.28858 0,0 z m 557.83555,0.0387 0.8655,0.10679 -0.8655,-0.10679 z m -565.0043,-0.55003 c 0.59208,-7.55856 3.86422,1.72578 0,0 z m 346.37129,-0.88029 c -10.54529,-8.8197 9.31625,-12.95413 0,0 z m 22.94213,0.47241 c -4.44669,-14.94821 11.30595,-0.0126 0,0 z m 115.03628,0.19047 c -2.5423,-6.24044 8.0105,-2.59165 0,0 z m 8.9887,-1.44007 c 0.56,-3.67297 0.1798,4.7121 0,0 z m -185.08778,0.57181 c 0.81114,-5.32311 6.9505,1.27161 0,0 z m 26.23945,0.2447 c -7.89372,-14.3101 13.6897,-7.1514 0,0 z m 16.58372,-0.2426 c -0.27255,-17.60103 8.66026,3.80278 0,0 z m -35.31156,-0.092 c -2.30567,-5.54709 5.23593,-0.23478 0,0 z m 45.20237,-1.04735 c -3.18339,-23.68328 15.44466,4.96237 0,0 z m 298.5231,0.559 c -3.7585,-0.96794 1.0761,-23.58136 3.1564,-0.48979 l -2.1304,0.99409 -1.0257,-0.5043 -3e-4,0 z m -635.86386,-1.33829 c 0.82574,-5.50251 3.06039,2.79279 0,0 z m 471.74996,0.47707 c -0.5292,-3.76289 2.8094,0.95763 0,0 z m -380.22711,-0.57837 c 1.15641,-2.2715 1.15641,2.27147 0,0 z m 363.21631,0 c 1.1563,-2.27126 1.1563,2.27123 0,0 z m 11.0212,-0.241 c 1.4561,-3.40254 1.7245,2.78942 0,0 z m -373.10585,-0.62658 c 0.22342,-7.08616 7.10573,2.5816 0,0 z m 365.23905,0.36682 c -1.4883,-2.8029 1.8665,0.57031 0,0 z m 69.9201,-0.0777 c 0.631,-2.19298 1.0755,2.23979 0,0 z m -553.92885,-0.57839 c 0.73744,-2.38842 1.51244,2.51991 0,0 z m 328.47604,0 c 1.15639,-2.27149 1.15639,2.27148 0,0 z m -16.97714,-1.66939 c 1.37322,-3.10065 3.46208,1.54302 0,0 z m -189.30869,-1.22251 c 0.6308,-2.19303 1.07549,2.23979 0,0 z m -7.60053,-0.86758 c 2.09144,-3.76316 0.60419,3.48354 0,0 z m 557.69597,0.28919 c 0.6309,-2.1931 1.0757,2.23987 0,0 z m -641.85781,-0.51004 c 0.4478,-2.85559 1.80038,1.11577 0,0 z m 95.95521,0.0936 c -2.71913,-3.42635 2.80742,-0.054 0,0 z m 360.2215,-1.28442 c 0.073,-3.89865 1.4233,3.11188 0,0 z m 17.9331,0.35063 c -3.692,-18.0308 5.0181,1.18038 0,0 z m -492.79778,-0.96315 c 2.2828,-6.33502 1.99201,5.81652 0,0 z m 361.99077,0.52444 c 0.2657,-5.74058 4.61198,1.6615 0,0 z m 283.58071,0.24927 c -3.2034,-5.20613 8.1238,2.46638 0,0 z m 7.3224,-0.36488 c -0.9424,-5.31332 1.8182,2.60039 0,0 z m 3.3856,-0.89686 c -0.032,-3.09873 2.4846,0.7147 0,0 z m -608.12221,-0.66874 c 1.64452,-2.406 1.23936,2.35869 0,0 z m 429.66191,-0.65856 c 1.2857,-4.38991 1.3254,4.06449 0,0 z m 11.8999,0.38752 c 1.9344,-2.31841 0.9075,3.10394 0,0 z m -8.7849,-0.11455 c -3.582,-8.01677 4.3761,0.88565 0,0 z m 3.0349,-0.80532 c 1.4274,-1.28308 0.8806,2.1938 0,0 z m 161.243,-0.54423 c -0.3012,-4.52872 4.0463,5.64895 0,0 z m -652.78306,-1.27245 c -2.76558,-5.18758 4.14611,2.04267 0,0 z m 58.65993,-1.13347 c 0.12327,-7.67762 1.79557,6.77606 0,0 z m -38.27092,0.85045 c -2.39014,-6.02882 6.14987,0.4174 0,0 z m 4.43236,-2.23816 c 1.5119,-2.12333 0.16885,2.95414 0,0 z m 631.11419,-0.014 c 0.8846,-1.405 -0.053,2.65158 0,0 z m -2.6732,-0.81938 c 1.1564,-2.27148 1.1564,2.27148 0,0 z m 6.339,-0.34944 c -1.9773,-2.67615 2.3147,-0.95769 0,0 z m -326.18989,-0.74306 c -5.09778,-4.5307 8.8155,0.51998 0,0 z m 8.72675,-0.9074 c -0.7879,-10.57331 7.35372,6.46347 0,0 z m 8.07708,-0.25833 c -2.06037,-14.14163 10.42255,4.48126 0,0 z m 12.74549,1.29426 c -0.37374,-5.00201 5.40532,3.39941 0,0 z m 5.5504,-0.35326 c -5.49111,-8.29046 7.80844,2.45055 0,0 z m 173.09187,0.13906 c -13.2654,4.19626 -42.9059,-11.34683 -19.7424,-20.32173 13.2034,-4.81878 42.7901,2.09058 19.7424,20.32173 z m -24.8563,-6.18416 c -2.2059,-0.13945 1.1197,2.73078 0,0 z m 27.9819,-5.10703 c -1.5782,-4.12558 -0.6444,5.15047 0,0 z m -27.7996,-2.424 c 0.09,-4.36481 -2.1132,0.99484 0,0 z m 10.8666,-4.33786 -0.023,1.41117 0.023,-1.41117 z m -200.61345,17.49607 c 1.1564,-2.27148 1.1564,2.27148 0,0 z m 320.09035,-0.81309 2.3868,-0.65166 -2.3868,0.65166 z m 7.849,-0.0268 c -2.3126,-6.59386 4.8788,2.09937 0,0 z m -349.10923,-0.48088 c 3.15518,-11.81505 5.24162,3.02483 0,0 z m 8.49676,-0.38092 c -1.03099,-8.03315 6.98895,3.28556 0,0 z m 21.52581,-1.21375 c -10.09659,-1.09771 5.74596,-4.00606 0,0 z m 26.6238,-0.81872 c -1.05707,-5.1774 3.47124,2.99558 0,0 z m 131.19216,-1.75466 c -15.0025,-11.93634 9.2776,-22.00982 3.4528,-2.60504 -5.3558,-17.94365 2.8103,10.41041 -3.4528,2.60504 z m -0.3942,-4.3437 c -0.6308,-2.19303 -1.0755,2.23979 0,0 z m 6.6513,2.18929 c -2.0877,-15.47667 3.4428,-8.64958 1.0818,1.30227 l -1.0818,-1.30227 z m -505.2352,1.85939 c 1.51243,-2.51992 0.73744,2.38841 0,0 z m 374.47706,0 c 1.07549,-2.23979 0.6308,2.19302 0,0 z m 115.39084,-1.59056 c -5.3851,-8.57136 7.4458,-9.35899 0,0 z m 167.3237,1.59056 c 1.2393,-2.35869 1.6445,2.406 0,0 z m -666.53554,-0.51095 c 2.13718,-3.22602 2.48369,2.45662 0,0 z m 496.76154,-0.29485 c -1.1006,-4.72139 1.6424,2.67831 0,0 z m -129.9514,-0.35098 c 0.18531,-4.8206 4.40503,2.13755 0,0 z m 303.3612,-0.87157 c -5.2828,-8.3975 4.2574,3.00242 0,0 z m -298.32981,-0.27313 c -1.201,-5.02514 6.35965,2.57624 0,0 z m 4.31264,0.0498 c 0.18593,-19.09384 15.77631,0.005 0,0 z m -48.19706,-0.59204 c 6.34115,-17.43736 46.26655,0.51838 13.09165,-1.43315 -4.39632,0.005 -8.71652,1.08707 -13.09165,1.43315 z m 19.92554,-3.78734 c -2.71886,-4.49266 2.61694,-2.92506 0,0 z m 38.57167,3.15667 c 1.33379,-5.30095 2.51334,3.12343 0,0 z m -61.82925,-1.32896 c -16.2186,-10.56418 7.2477,-3.07782 0,0 z m 49.92606,0.4064 c -2.88727,-6.50518 4.66653,0.90218 0,0 z m 13.1033,-2.83285 c 1.14598,-3.19628 1.14589,3.19632 0,0 z m -378.00324,-1.07776 c 2.55811,-3.7315 -1.58542,4.2527 0,0 z m 357.17737,0.009 c -2.16317,-5.27243 3.77058,1.85186 0,0 z m 129.87278,-1.07625 c 0.5409,-10.35963 -4.0658,-1.24716 0,0 z m -111.20324,-1.03562 c 1.64452,-2.40601 1.23936,2.35868 0,0 z m -375.43533,-0.79909 c 0.18772,-3.92704 1.98454,2.07237 0,0 z m 305.71504,-0.0762 c -3.52599,-12.11095 4.86218,0.62486 0,0 z m 55.58458,0.0366 c -7.01281,-9.09435 6.04119,1.03575 0,0 z m 127.97395,-1.61933 c -0.2582,-6.6534 2.2836,2.21335 0,0 z m -490.14843,-1.77241 c -3.18429,-15.55982 4.8199,2.38693 0,0 z m 73.23061,0.42286 c 1.68022,-2.78184 1.45164,3.3953 0,0 z m 237.67922,-0.0964 c 0.73584,-4.72086 0.61488,2.93865 0,0 z m -120.45827,-0.55157 c -12.41758,-12.65533 4.96579,-27.12331 0.58924,-2.10357 l 0.52728,1.33807 -1.11652,0.7655 z m -201.20576,-1.86045 c 0.12435,-2.65926 1.08742,2.52385 0,0 z m 426.83613,-0.0463 c 1.0754,-2.2398 0.6308,2.19302 0,0 z m 3.8145,-1.59056 c -1.8926,-10.88336 9.1737,-1.44456 0,0 z m -426.38257,0.1446 c 0.27975,-3.24609 2.53602,4.12663 0,0 z m -4.61848,-1.12264 c 0.70557,-3.10358 1.56512,2.21168 0,0 z m 117.87756,-2.38395 c -17.35746,-15.06505 19.16408,-3.35408 0,0 z m -0.71874,-5.45838 c -0.63081,-2.19303 -1.07549,2.23979 0,0 z m 504.20233,4.2753 c -12.2528,-7.02324 -45.0603,6.79647 -27.5396,-22.59808 11.1761,15.18959 16.1429,-6.85028 28.4085,8.06809 -3.098,9.31976 5.4996,-18.20056 17.449,-4.81651 11.6448,-5.80529 6.3966,9.06031 12.7836,-0.67229 4.9716,18.67146 10.7856,-15.8484 8.5101,13.74743 -5.8732,13.32058 -29.3001,-1.9928 -39.6116,6.27136 z m 2.0484,-2.47364 c -2.8898,-6.4339 -4.3407,3.44542 0,0 z m 24.8309,-4.13715 c -2.7301,-4.1904 -0.3257,8.11121 0,0 z m 8.2324,-0.31544 c -1.6802,-2.78179 -1.4517,3.39529 0,0 z m -25.0994,-2.44393 c -3.2464,-2.45314 1.3841,4.13679 0,0 z m -34.4292,-1.84574 c -2.2885,-10.2747 -0.8575,8.9434 0,0 z m 16.8818,2.31354 c -1.6446,-2.40607 -1.2393,2.35874 0,0 z m 0.793,-3.78443 c 0.188,-4.10429 -2.6673,3.66791 0,0 z m 16.7405,-0.62522 c -2.8518,-1.56501 0.9713,3.74885 0,0 z m 7.2318,-2.06102 -0.088,1.045 0.088,-1.045 z m -101.2108,10.81974 c -11.0522,-4.01717 5.6929,-26.55418 2.4314,2.15575 -0.4696,3.11861 -5.1628,1.02031 -2.4314,-2.15575 z m 3.7737,0.42258 c -3.2102,-18.61529 5.9361,-20.82575 0,0 z m 147.7045,1.6459 c -3.5363,-34.63917 32.0191,-6.67877 45.819,-18.01444 -1.3812,25.78407 6.9173,9.97731 -6.2214,11.89062 -7.2423,10.3146 -28.7945,2.43865 -39.5976,6.12382 z m 5.514,-8.32981 c -2.5153,1.0723 2.8355,4.02432 0,0 z m 15.768,1.29974 c -1.5652,-2.21168 -0.7056,3.10354 0,0 z m -7.4786,-0.88075 c 0.8086,-4.45216 -2.7173,2.96858 0,0 z m 20.9494,-0.98655 c -2.3028,0.94206 1.9965,2.6445 0,0 z m -6.6666,-1.10616 c -2.1835,-0.53938 1.5166,4.24047 0,0 z m -22.3276,-1.46282 c -2.2059,-0.13953 1.1197,2.7308 0,0 z m 36.6071,-2.21512 c -2.1552,-3.23672 -0.8478,4.15691 0,0 z m -303.9711,13.8032 c 6.1116,-20.81241 -0.9858,-34.50817 -0.7835,-67.08015 -6.7992,-16.08196 7.4845,-60.68103 6.1885,-20.60992 1.2649,34.61278 5.6887,55.54248 3.6142,77.22575 -13.9213,-0.25366 7e-4,10.182 -9.0192,10.46432 z m 3.0478,-37.80608 c -1.5651,-2.21168 -0.7055,3.10359 0,0 z m -2.6559,-5.78966 c -2.3192,-2.68517 -0.4994,3.3168 0,0 z m 0.26,-2.56276 c -2.6392,-4.90622 -1.0483,4.04748 0,0 z m 1.9167,-8.06321 c -1.867,-2.51495 -1.1178,1.53132 0,0 z m 2.7555,-7.69772 c -2.1485,-3.07955 -2.1798,3.5898 0,0 z m -0.7509,-28.03227 c -1.95,-0.6568 1.9405,2.57864 0,0 z m -5.3588,-7.1386 c -1.5651,-2.21166 -0.7055,3.10354 0,0 z m 118.5897,96.3097 c -7.276,-17.15002 11.5437,-19.03497 3.9299,-4.06547 -0.2313,-15.45482 -0.4269,6.18475 -3.9299,4.06547 z m 194.0634,0.58371 c -9.7855,-27.19316 16.9266,-18.62598 0,0 z m 6.8212,-0.33829 c -9.2435,-23.88643 14.7664,-20.52766 0,0 z m -241.608,-0.79869 c 0.6309,-2.19318 1.0756,2.23978 0,0 z m 8.8721,-0.4338 c 0.1759,-4.38294 2.5796,1.27567 0,0 z m -404.20816,-0.75202 c -0.52471,-3.21035 2.4205,1.51077 0,0 z m 401.07896,0.0149 c -1.5382,-11.96505 3.4841,2.81142 0,0 z m 20.7343,-0.3454 c -3.928,-16.69953 4.7427,-7.65537 0,0 z m -29.2724,-0.60446 c -2.0201,-4.24807 2.6248,-0.7116 0,0 z m 5.7578,-1.57173 c -0.6036,-3.39653 2.4413,0.89085 0,0 z m 6.1412,0.0775 c -1.706,-6.75001 2.8184,1.60485 0,0 z m 39.6429,0.0463 c -1.4021,-16.76956 4.8839,-14.76071 0,0 z m -118.3472,-0.6882 c -3.7515,-4.5125 5.7368,2.51999 0,0 z M 253.79304,716.0623 c -0.9832,-4.12513 3.32945,1.55994 0,0 z m 406.76808,-1.49034 c -0.7992,-14.42933 2.1184,5.48005 0,0 z m -12.7173,0.28539 c -0.09,-4.36474 2.1131,0.99464 0,0 z m -388.83924,-0.68296 c 0.21103,-3.17016 1.84114,2.26061 0,0 z m 641.62914,-1.54125 c -0.9903,-9.23386 4.3012,5.8838 0,0 z m -317.9485,-0.77422 c -1.5699,-5.36767 3.4313,3.93275 0,0 z m 68.2108,0.28629 c -0.6757,-7.57571 3.7147,3.41009 0,0 z m 2.6979,-0.17972 c 0.3622,-7.63587 2.5561,3.68133 0,0 z m -363.84259,0.0723 c -0.89872,-5.42068 2.52428,0.45716 0,0 z m 3.94939,-0.89781 c 4.19284,-3.72319 -2.11359,4.1857 0,0 z m 363.2401,0.71502 c 0.7056,-3.10369 1.5652,2.21181 0,0 z m 44.0843,-0.36135 c 0.364,-4.16175 3.4066,-1.71826 0,0 z m -53.1886,-1.69712 c 1.1141,-5.10111 1.1142,5.10109 0,0 z m -2.6356,0.28919 c 0.6309,-2.19317 1.0756,2.23979 0,0 z m 60.616,-0.25505 c 0.6449,-4.11301 1.6003,3.16338 0,0 z m -374.39714,-0.13053 c -1.74786,-2.54956 2.19602,0.37204 0,0 z m -41.25199,-0.7387 c 8.37073,-23.25754 -8.10333,-14.16586 -1.11669,-42.65196 -4.35545,-7.76365 7.93386,-32.06861 -5.3982,-21.43463 0,-26.27861 -5.41786,-56.59778 -7.49398,-85.69326 0.592,-23.76964 -37.91488,-19.68837 -29.50954,3.56659 -12.60921,6.78192 -20.1696,-5.96871 -18.52035,3.31995 -4.97852,-21.35188 -12.75813,13.05916 -17.26196,-1.81601 -19.3031,9.29949 -20.21633,-23.17825 -28.79337,-10.23948 -13.44928,-7.9406 -20.17735,-13.75242 -20.19328,-5.37685 -1.60251,-17.17355 -24.25964,-8.85326 -17.65761,-34.4539 -0.62199,-38.11571 0.71047,-76.19945 -0.76823,-114.13339 18.32268,-19.54469 55.34017,-3.31655 81.03622,-8.64764 75.98614,0.0644 152.31871,-0.37964 228.08028,1.05828 -2.93871,16.68703 -7.91998,32.00184 -17.96352,34.10656 8.38655,14.04529 -6.68615,8.73614 -0.56307,19.4997 -17.26873,2.96916 10.41854,17.97553 -12.16667,16.18731 0.75719,13.95967 -10.19895,9.1148 -0.82368,23.41995 15.72558,-11.13203 12.57468,68.04033 -8.16413,44.10364 -19.54022,-1.61509 -9.8949,29.51832 -25.29303,26.85212 23.01325,18.34217 4.25443,52.90505 -15.90903,26.44784 3.47223,-18.95116 11.86706,-35.72443 -9.61301,-24.26013 -0.10859,19.28163 -1.22938,41.8523 -13.86833,40.52436 -3.76461,-10.73961 1.21061,-31.18294 -9.27922,-44.56297 -2.03545,1.90071 -3.20333,-20.20895 -7.54615,1.98719 -8.01219,-1.30812 -26.5743,0.2144 -15.85811,7.72223 -22.03656,-7.20285 -13.64119,56.2012 -16.6228,80.173 -7.21147,34.53289 3.50311,52.58898 33.21256,45.44597 31.79982,8.1217 -13.9892,23.29473 -21.32396,2.81059 -16.83622,-2.67299 -5.00468,22.41362 -20.62114,16.04494 z m 5.94293,-7.85462 c -2.21498,-2.91325 0.73823,2.94602 0,0 z m 9.95249,-9.28843 c -2.50818,-0.66639 0.0311,3.10158 0,0 z m -13.48541,-8.67476 c -0.59965,-7.88416 -6.67805,3.22134 0,0 z m 2.34466,-4.29056 c -2.30782,-2.53077 -2.30782,2.53076 0,0 z m -0.45484,-4.32846 c 4.11967,-16.01178 -11.37662,6.66551 0,0 z m -2.18107,-9.26266 c 0.98979,-6.45764 -3.52064,4.88465 0,0 z m 3.83378,0.2883 c -1.7329,-2.43775 -1.7329,2.43777 0,0 z m -4.79177,-4.04868 c -0.6308,-2.19302 -1.07549,2.2398 0,0 z m 5.40984,-4.04866 c -2.24763,-6.54457 -0.84575,5.06129 0,0 z m -4.91175,-1.14269 c -3.261,-1.55991 1.0648,3.7886 0,0 z m 2.85619,-10.42497 c -5.90669,-9.88696 -5.66477,-9.62559 0,0 z m 0.47914,-5.78383 c -1.07549,-2.23979 -0.63081,2.19303 0,0 z m -8.62519,-9.8325 c -1.07549,-2.23978 -0.63081,2.19303 0,0 z m 1.00811,-1.90647 c -2.47328,-1.43944 0.60365,3.19544 0,0 z m -5.79989,-20.03794 c -1.70095,-4.62195 -1.49365,2.2287 0,0 z m 10.5419,-0.57839 c -0.70556,-3.1037 -1.56521,2.21182 0,0 z m -11.02104,-6.39633 c -0.6308,-2.19304 -1.07549,2.23978 0,0 z m 5.75014,-0.57839 -1.93292,0.32483 1.93292,-0.32483 z m 66.1264,-6.94059 c 9.04913,-9.19669 -5.08666,-7.12122 0,0 z m 5.75012,-3.92936 c 3.75287,-10.85391 -5.41011,2.95526 0,0 z m 40.01139,-3.58961 c -1.23936,-2.35868 -1.64452,2.40601 0,0 z m -44.32394,-2.12412 c 11.52438,-5.53195 -5.03592,-3.71314 0,0 z m -3.35428,-0.22355 c -1.56522,-2.2118 -0.70558,3.1037 0,0 z m -2.15624,-2.85777 c 0.30681,-4.14089 -4.6434,2.17378 0,0 z m 33.75507,-2.83118 c -2.76096,-7.53229 -13.0021,1.81969 0,0 z m 6.17425,-1.21751 c -3.40573,-8.17414 -2.20394,7.12747 0,0 z m -33.93967,-2.67098 c -1.98453,-2.0724 -0.18772,3.92702 0,0 z m 24.91723,-3.43616 c -1.82174,-3.04266 -0.87424,4.19365 0,0 z m -76.66652,-2.85642 2.36148,-2.43155 -2.36148,2.43155 z m 78.2774,1.1554 c -1.07522,-3.17948 -0.45261,3.09705 0,0 z m 8.93102,0.2892 c -1.15639,-2.27148 -1.15639,2.27148 0,0 z m -87.7738,-5.97811 c -2.22024,-4.54994 2.3363,-3.59982 0,0 z m -100.30319,-0.96249 c -0.63089,-2.19309 -1.07566,2.23986 0,0 z m 8.38559,-0.28918 c -4.33525,-4.2924 -1.6828,2.43885 0,0 z m 24.33368,-0.19983 c -2.10514,-2.60176 -1.9816,3.65128 0,0 z m 146.62278,0.38057 c -1.49463,-3.35541 -1.66846,2.78344 0,0 z m 2.98482,-1.39939 -1.42165,0.32217 1.42165,-0.32217 z m -184.48319,-0.83985 c -1.56513,-2.21168 -0.70557,3.10359 0,0 z m 4.64874,0.0534 c 5.47029,-9.20733 -10.50194,0.1804 0,0 z m 101.51717,0.29042 c 0.9872,-10.7423 -8.00311,2.53684 0,0 z m -95.624,-1.43218 c -0.70558,-3.10357 -1.56513,2.21165 0,0 z m -12.71309,-0.5835 c -1.06571,-4.22878 -3.69804,2.19649 0,0 z m 15.10893,-1.9891 c -3.86431,-9.35294 -8.14268,5.58669 0,0 z m 18.68797,0.89971 c -1.25922,-4.00994 -1.33353,1.99376 0,0 z m 77.51681,-0.56634 c -1.66837,-2.78348 -1.49454,3.35546 0,0 z m 21.19365,0.18075 c -1.1459,-3.19631 -1.14599,3.1963 0,0 z m -108.08805,-0.22366 c 2.49108,-9.5182 -3.291,2.44696 0,0 z m 54.8994,-0.0655 c -1.07549,-2.23979 -0.63081,2.19303 0,0 z m 106.3773,-0.28919 c -3.75536,-5.18473 -2.64836,4.67284 0,0 z m -81.9393,-1.41181 c -0.76876,-7.37856 -1.30548,6.11525 0,0 z m 64.88855,0.17225 c 0.18595,-4.83752 -2.10299,3.74689 0,0 z m -136.77246,-0.351 c -0.89356,-6.39343 -3.1105,2.28812 0,0 z m 74.75898,0.46792 c -0.88074,-2.19395 -1.42752,1.28319 0,0 z m 23.77052,-0.65982 c -10.37394,3.14289 -2.15871,3.66847 0,0 z m -121.0435,-1.17772 c -1.98454,-2.0724 -0.18772,3.92701 0,0 z m 27.31316,0.93583 c -1.64452,-2.406 -1.23936,2.35869 0,0 z m 8.86472,0 c -0.73735,-2.38854 -1.51253,2.51977 0,0 z m 72.34782,-0.5629 c 15.44032,0.0557 8.27103,-8.21216 0,0 z m -111.99258,-5.11247 c -2.53265,-10.07296 -3.56274,14.99485 0,0 z m 8.01913,4.51861 c -2.09241,-2.55358 -1.35008,2.47989 0,0 z m 153.18058,-0.70894 c -2.80307,-1.62162 0.39546,3.30299 0,0 z M 218.97281,552.4766 c -4.00013,-5.56197 -1.06829,4.07366 0,0 z m 86.95021,0.32914 c -0.63366,-3.45296 -2.28574,2.35781 0,0 z m 62.07393,-0.04 c -0.63081,-2.19304 -1.07549,2.23978 0,0 z m 13.65658,0 c -0.6309,-2.19309 -1.07567,2.23986 0,0 z m -69.00155,-2.02434 c -1.42041,-4.69523 -1.42041,4.69523 0,0 z m -114.87273,0.18075 c -1.49462,-3.35541 -1.66847,2.78347 0,0 z m 78.91399,0.14841 c -0.0454,-2.94668 -1.5807,1.98526 0,0 z m 33.02813,-0.47376 c 2.22522,-4.6793 -6.30706,-1.74102 0,0 z m 33.83757,0.21542 c -1.28617,-6.64951 -2.31813,3.13626 0,0 z m -152.85756,-0.36001 c -1.15631,-2.27125 -1.15631,2.27125 0,0 z m 17.72952,-0.2892 c -1.14598,-3.19628 -1.14589,3.19632 0,0 z m 96.48178,-1.54255 -0.89694,1.61231 0.89694,-1.61231 z m 20.24784,0.83163 c -2.2058,-0.13954 1.11955,2.7307 0,0 z m -6.03967,-0.15664 c -1.64452,-2.406 -1.23936,2.35869 0,0 z m -106.85653,-0.54461 c -0.70556,-3.10372 -1.56521,2.2118 0,0 z m 29.22987,-0.54571 c -0.8535,-10.20857 -4.17744,4.41102 0,0 z m 89.99333,-1.54799 c 2.13104,-8.40773 -8.97776,7.68282 0,0 z m -138.39029,1.72905 c -2.36167,-4.97952 -4.03806,0.88638 0,0 z m -16.29195,-0.82625 c -1.15631,-2.27125 -1.15631,2.27125 0,0 z m 50.31359,0.32333 c -1.86731,-2.51498 -1.11777,1.53127 0,0 z m 17.72952,-0.32333 c -1.07549,-2.23978 -0.6308,2.19302 0,0 z m 79.84323,-1.99464 c -4.39959,-5.60032 1.1314,6.80283 0,0 z m 73.97269,1.73959 c -0.88074,-2.19373 -1.42743,1.28305 0,0 z m -210.59838,-0.90172 c -0.6308,-2.19303 -1.07549,2.23979 0,0 z m 8.47343,-0.70371 c -1.95018,-0.65695 1.94048,2.57869 0,0 z m 116.35223,0.70371 c -1.07567,-2.23986 -0.63089,2.19309 0,0 z m 60.37627,0 c -1.07549,-2.23978 -0.6308,2.19304 0,0 z m -68.04311,-1.15676 c -2.90212,-4.53784 0.39493,4.00517 0,0 z m 37.08496,0.24188 c 0.80838,-4.45219 -2.71725,2.96869 0,0 z m -98.89881,-0.24188 c -1.07566,-2.23986 -0.63089,2.19309 0,0 z m 154.05545,0 c -2.97717,-2.65016 -2.27525,2.5685 0,0 z m -218.04609,-0.53847 c -1.49356,-8.02012 -4.8668,3.02107 0,0 z m 14.3958,-0.61835 c -1.15631,-2.27124 -1.15631,2.27125 0,0 z m 77.27739,-0.47032 c -1.3516,-1.59166 -1.97475,3.24102 0,0 z m 112.77025,-0.85273 c -2.30265,0.94192 1.99629,2.64457 0,0 z m -114.76698,-0.25546 c -2.20572,-0.13942 1.11972,2.7307 0,0 z m 42.35729,1.00014 c -1.1564,-2.27149 -1.1564,2.27147 0,0 z m 6.10385,-0.39937 c -5.54443,-2.94026 2.60884,3.73839 0,0 z m 72.72291,0.39528 c -1.33388,-5.30101 -2.51316,3.12329 0,0 z m -52.94681,-0.85712 c -3.0732,-2.4726 0.31028,3.01063 0,0 z m 2.8707,0.28282 c -1.64453,-2.406 -1.23935,2.35869 0,0 z M 172.0135,542.42188 c -3.43386,-6.6484 -3.51975,4.42675 0,0 z m 30.18814,-0.0675 c -1.73309,-2.4379 -1.73309,2.43788 0,0 z m 3.83342,-0.57839 c -1.07549,-2.23978 -0.6308,2.19302 0,0 z m -37.37584,-2.09515 c -2.997,-4.8889 -1.65761,8.29907 0,0 z m 227.27876,0.8927 c -1.77315,-3.60274 -1.70852,4.30621 0,0 z m -235.1594,-0.005 c 0.057,-6.88435 -4.51397,4.57455 0,0 z m 230.69802,-1.14059 c -1.77501,-2.48384 -1.58222,3.09083 0,0 z m -225.39257,-0.23597 c 0.55603,-4.80173 -3.14174,4.24581 0,0 z m 91.51251,-0.73002 c -2.2058,-0.13951 1.11956,2.73067 0,0 z m -80.79126,0.42174 c -1.15631,-2.27124 -1.15631,2.27125 0,0 z m 216.28745,-2.16893 c -1.85806,-8.85645 -1.43473,8.80727 0,0 z m -51.92972,1.59055 c -0.6308,-2.19303 -1.07549,2.23979 0,0 z m -178.73305,-0.57839 c -0.6309,-2.19309 -1.07567,2.23987 0,0 z m 160.76392,-0.57837 c -1.23935,-2.35869 -1.64453,2.406 0,0 z m -17.96913,-0.57839 c -1.07567,-2.23986 -0.6309,2.1931 0,0 z m -130.8154,-0.90171 c -1.5119,-2.12331 -0.16885,2.95415 0,0 z m 151.30009,-1.1709 c -2.50817,-0.66635 0.0312,3.10155 0,0 z m -164.24522,-0.99782 c -2.54788,-0.33297 0.59341,4.03655 0,0 z m -12.41536,0.59807 c -1.94217,-1.36962 -0.23445,2.1418 0,0 z m 5.71426,-1.32104 c -2.15517,-3.23679 -0.84799,4.15693 0,0 z m 179.21228,0.9017 c -0.6309,-2.1931 -1.07567,2.23986 0,0 z m -175.85808,-0.57839 c -1.1564,-2.27148 -1.1564,2.27148 0,0 z m 6.46887,0 c -2.27506,-2.56842 -2.97707,2.65012 0,0 z m 197.66063,-1.15676 c -0.6308,-2.19303 -1.07549,2.23978 0,0 z m -212.7547,-2.33472 c -2.69082,-9.18469 -3.03306,7.78392 0,0 z m 277.92284,1.17766 c -1.733,-2.43766 -1.733,2.43769 0,0 z m -266.90171,-1.22503 c -1.8002,-1.11574 -0.4478,2.85545 0,0 z m -11.02113,-3.94626 c -0.70557,-3.10373 -1.56521,2.21179 0,0 z m 260.67244,-0.90173 c -1.14589,-3.19611 -1.14589,3.19615 0,0 z m -80.19375,-0.57838 c 0.9078,-3.26524 -3.05788,3.94188 0,0 z m 94.56908,-0.9017 c -2.06945,-5.84822 -1.9703,5.24372 0,0 z m -269.40747,0.14258 c -1.66838,-2.78349 -1.49455,3.35543 0,0 z m 177.4054,-2.42198 c -1.1564,-2.27148 -1.1564,2.27148 0,0 z m 3.83341,-0.57838 c -1.15639,-2.27149 -1.15639,2.27148 0,0 z m 68.04321,-1.1909 c -1.56513,-2.21168 -0.70558,3.10355 0,0 z m -6.54115,-6.59874 c -0.48297,-3.76555 -2.73417,3.89263 0,0 z m -8.07379,-0.30772 c -1.23935,-2.35869 -1.64452,2.406 0,0 z m 22.83336,-3.23574 c -3.82052,-8.43434 -3.768,8.61225 0,0 z m -17.07975,-0.22139 c 15.01253,-6.39403 -5.26655,-8.87183 0,0 z m -8.95916,-0.37079 c -3.30418,-3.19304 0.13743,3.90115 0,0 z m 4.43948,0.19857 c -1.94226,-1.36978 -0.23463,2.14189 0,0 z m 7.35211,0.38636 c 2.30362,-3.38791 -3.86974,1.00773 0,0 z m -22.5132,-1.44467 c -1.9589,-2.21647 -0.83455,3.02967 0,0 z m 5.53419,-0.95157 c -0.3466,-4.40449 -3.64526,1.74762 0,0 z m -8.58185,-0.88204 c -1.94226,-1.36977 -0.23463,2.1419 0,0 z m 20.0895,-0.48758 c -1.8002,-1.11577 -0.44789,2.85546 0,0 z m -248.36568,-1.19695 -0.0881,1.04497 0.0881,-1.04497 z m 246.32507,-0.33871 c 2.51858,-7.35896 -9.8342,7.29758 0,0 z m -7.73262,-1.70937 c -2.20581,-0.13953 1.11955,2.7307 0,0 z m -3.65576,-1.55919 c -3.0254,-0.66256 1.80163,4.27946 0,0 z m -3.10266,0.82416 c -1.64451,-2.40599 -1.23935,2.3587 0,0 z m 27.55268,-1.15676 c -2.80172,-5.30407 -1.83027,3.73921 0,0 z m -4.77486,-1.11874 c 8.00578,-14.04759 -3.07952,-4.82643 0,0 z m -9.60045,-0.0999 c -3.0214,-2.55799 -3.95493,1.96944 0,0 z m 3.20243,-1.78171 -0.0882,1.04494 0.0882,-1.04494 z m 15.12166,-1.73474 c -2.2059,-7.91124 -2.27586,9.07421 0,0 z m -2.99042,0.0316 c -3.29171,-2.48272 -0.50815,6.27032 0,0 z m -21.32333,1.23318 c -0.63089,-2.19309 -1.07567,2.23986 0,0 z m 8.38559,-1.73514 c -1.23936,-2.3587 -1.64453,2.40599 0,0 z m 5.9212,-3.32572 c -5.16989,-4.01147 -2.55276,9.23999 0,0 z m -2.64649,-1.84486 c -1.60118,-3.97811 -1.16806,5.8007 0,0 z m 15.88499,0.10972 c -0.74936,-9.09376 -1.85903,4.98163 0,0 z m -18.68058,0.43379 c -1.15639,-2.27149 -1.15639,2.27148 0,0 z m 15.63961,-0.28919 c -0.54127,-6.79553 -10.82896,4.89969 0,0 z m -6.69318,-1.78331 c -1.00749,-10.81269 -2.74458,4.55222 0,0 z m 1.59547,-1.97616 c -1.15639,-2.2715 -1.15639,2.27147 0,0 z m 4.30668,-0.723 c -4.96498,-10.45991 -4.24062,3.14798 0,0 z m 3.83939,0.40507 c 0.0107,-10.81488 -4.57085,1.46738 0,0 z m 7.66684,-0.26046 c -0.6309,-2.1931 -1.07567,2.23986 0,0 z m -5.15119,-2.54029 c 3.40262,-5.08071 -9.87203,-1.49223 0,0 z m -23.24013,-1.84586 c -2.50808,-0.66644 0.0311,3.10158 0,0 z m 7.72381,0.71804 c -0.60321,-4.51036 -4.57228,4.12865 0,0 z m 9.64638,-0.95896 c -1.15639,-2.27147 -1.15639,2.27148 0,0 z m 6.6542,-2.20351 c -5.84725,-19.83715 -11.47605,-3.03286 0,0 z m -10.96675,-0.9776 c -1.04869,-2.21751 -3.86679,4.20651 0,0 z m 3.83342,-0.57839 c -1.7346,-3.40693 -1.7346,3.40697 0,0 z m -1.9167,-8.96492 c -1.15632,-2.27125 -1.15632,2.27124 0,0 z m 3.35419,-2.60272 c -1.14598,-3.19629 -1.14598,3.19629 0,0 z m 8.45189,0 c 9.16895,-8.39437 -10.15872,-6.07363 0,0 z m -5.0976,-2.02433 c -1.15632,-2.27125 -1.15632,2.27123 0,0 z m -4.79178,-4.04868 c -1.23935,-2.35869 -1.64452,2.406 0,0 z m 2.39148,-1.45994 c -3.45539,-3.65958 1.77625,5.66103 0,0 z m 12.25461,-0.81197 c -0.58452,-10.07987 -2.93159,5.07776 0,0 z m -17.04603,-0.60478 c 0.80447,-4.44587 -3.70454,3.2426 0,0 z m 10.54591,-0.0152 c -1.1564,-2.27147 -1.1564,2.27149 0,0 z m -0.95836,-1.92794 c -1.04014,-4.03667 -2.74056,3.65379 0,0 z m -2.39583,-3.2775 c -1.23936,-2.35869 -1.64453,2.406 0,0 z m 9.30833,-1.92763 c -2.69162,-3.58272 -0.0445,5.01538 0,0 z m -4.51656,-0.13085 c -1.82182,-3.04275 -0.87442,4.19363 0,0 z m 4.20147,-4.19067 c -2.78161,-1.48721 -3.13978,4.37687 0,0 z m 4.90285,0.75452 c -0.7482,-7.82507 -7.35922,1.9847 0,0 z m 0.47923,-5.2236 c -2.17173,-6.60595 -2.56897,4.4039 0,0 z m -9.58355,-3.16295 c -1.15631,-2.27126 -1.15631,2.27123 0,0 z m 11.97939,-0.64027 c -4.1219,-8.11052 -4.61144,3.53699 0,0 z m 0.81007,-2.56838 c 1.96397,-3.99866 -3.36693,3.55064 0,0 z m -6.5602,-0.26166 c -1.07549,-2.23977 -0.63081,2.19304 0,0 z m 9.7224,-1.15676 c 6.80782,3.04668 -3.49946,-8.57536 0,0 z m -5.88898,-0.25505 c -0.88074,-2.19395 -1.42751,1.28318 0,0 z m 3.35428,-5.23958 c 0.6026,-3.08233 -2.46099,3.18418 0,0 z m -5.27098,-1.44596 c -1.64453,-2.406 -1.23936,2.35868 0,0 z m 5.27098,-3.79362 c -3.36487,-4.69626 -3.19459,2.16773 0,0 z m -2.48057,-6.24053 c -2.39175,-3.30935 -2.53648,4.82354 0,0 z m 10.62655,0.49083 c -1.73451,-3.407 -1.73451,3.40704 0,0 z m 5.75013,0.61252 c -0.88074,-2.19395 -1.42752,1.28321 0,0 z m -1.71635,-4.14469 c 3.7987,-4.45578 -3.84535,-0.19392 0,0 z m -9.30469,-3.9868 c -1.1459,-3.19614 -1.1459,3.19612 0,0 z m 5.36989,-0.55531 c 6.60479,-5.2524 -5.59081,1.14124 0,0 z m 7.348,0.22764 c -1.46187,-7.1647 -4.5939,2.85022 0,0 z m -2.17599,-5.16696 c -1.1563,-2.27125 -1.1563,2.27124 0,0 z m 5.75014,-4.9215 c -5.20487,-10.93714 -3.73605,15.07205 0,0 z m -9.70336,0.14984 c -2.59691,-3.12739 -2.59691,3.12739 0,0 z m 3.7923,-1.26248 c -3.07747,-4.21715 -0.27512,4.72123 0,0 z m -2.34466,-3.69031 c -1.35159,-1.59165 -1.97475,3.24102 0,0 z m 0.4591,-1.61425 -0.87949,0.0329 0.87949,-0.0329 z M 282.22423,707.22752 c -0.1158,-10.60865 5.63807,3.49262 0,0 z m 43.92901,0.3116 c 2.75971,-5.67888 5.93286,5.08407 0,0 z m -8.46988,-0.27829 c 8.88519,-4.53262 3.18757,1.59513 0,0 z m 6.05596,-0.35664 c 2.14324,-3.39176 0.41407,3.08436 0,0 z m 20.77798,0.28919 c 1.73291,-2.43777 1.73291,2.43776 0,0 z m -12.21909,-0.57839 c 2.33808,-2.26451 2.86421,2.89272 0,0 z m 4.81224,0.04 c 0.21104,-3.17014 1.84115,2.26062 0,0 z m 368.82627,0.15536 c -4.0683,-7.82073 4.5901,-1.65571 0,0 z m -364.89351,-0.57838 1.16913,0.0276 -1.16913,-0.0276 z m 359.74851,-0.76176 c -0.7845,-8.64268 4.8232,3.1116 0,0 z m -442.68613,-1.55434 c -1.7549,-3.61063 3.31931,0.87147 0,0 z m 55.10545,-0.57838 c -1.41835,-5.0057 4.31362,0.57617 0,0 z M 904.67542,697.877 c 0.7152,-15.3692 1.0292,15.65662 0,0 z m -323.4446,0.97803 c 2.7647,-6.2061 7.4472,0.58966 0,0 z m 319.6112,-2.0384 c 0.6629,-5.17418 1.5502,4.13945 0,0 z m -332.0698,-0.90172 c 1.1459,-3.19611 1.1459,3.19614 0,0 z m -223.77578,-0.28918 c 1.1563,-2.27124 1.1563,2.27124 0,0 z m 538.95838,-1.30137 c -7.1295,-22.23507 9.0846,-20.08646 0,0 z m -44.0245,-1.40927 c -8.6375,-37.73864 16.1855,-11.14445 0,0 z m 9.1644,1.03745 c -11.6715,-29.909 12.739,-20.18952 0,0 z m 5.7487,-0.34767 c -12.0057,-38.19796 14.8344,-11.80418 0,0 z m 7.1322,0.43031 c -4.5948,-33.50463 13.0812,-6.29325 0,0 z m 7.2084,0 c -7.6907,-27.73155 12.8777,-10.81007 0,0 z m 7.2326,-0.41542 c -10.2295,-29.51354 13.9767,-11.89339 0,0 z m 13.5197,-0.12787 c -7.0204,-26.12262 10.5044,-16.84976 0,0 z m -244.9676,-1.77024 c 1.7651,-4.78951 0.1967,7.80004 0,0 z m 188.4291,1.57252 c -9.8291,-35.54531 14.3166,-13.73282 0,0 z m -549.16164,-0.87884 c -1.35881,-5.08156 3.51886,3.67378 0,0 z m 501.97214,0.50038 c -9.4925,-21.68116 11.1785,-30.2633 0,0 z m 7.3348,-0.41756 c -9.6223,-26.78563 15.2107,-22.84595 0,0 z m 7.8498,-1.93326 c -9.7387,-42.88506 14.6549,-1.21647 0,0 z m -617.16042,1.59055 c 0.63081,-2.19304 1.07549,2.23978 0,0 z m 577.10912,0.17109 c -10.1386,-23.55115 12.163,-16.61942 0,0 z m -166.1905,-0.73147 c 4.3793,-3.24704 2.5407,-13.56209 -0.6494,-13.53531 4.5015,-10.39698 -3.6966,-30.58071 15.5571,-34.6291 5.9497,-14.48787 -9.3729,-63.75426 12.9328,-29.89769 16.5149,17.80139 5.1893,42.20966 -15.4978,40.69579 -3.3977,10.1798 4.7167,42.1847 -12.3427,37.36631 z m 4.2884,-22.03068 c -1.6003,-3.16339 -0.6449,4.113 0,0 z m 5.5508,-18.84511 c 7.3185,-5.18003 -10.7312,-0.74512 0,0 z m 21.2831,-7.27173 c -2.9268,-2.02681 -1.3865,3.25582 0,0 z m -3.4299,0.19249 c -1.4802,-3.11126 -2.9965,2.54232 0,0 z m 1.5132,-3.86235 -1.1522,0.006 1.1522,-0.006 z m -0.2582,-3.29157 c -1.8739,-11.2715 -2.8951,7.79016 0,0 z m 2.3941,0.76294 c -0.045,-2.94662 -1.5805,1.9852 0,0 z m 1.3207,-7.28422 c -9.6367,-6.74476 -6.5407,2.47851 0,0 z m 0.5912,-3.79442 c -2.197,-1.33439 0.01,2.96862 0,0 z m -1.8379,-3.2763 c -2.282,-5.18684 -5.7111,4.81002 0,0 z m -8.4391,-5.81788 c -0.8195,-7.61554 -2.5977,1.17657 0,0 z m 0,-6.43862 c -0.7056,-3.10358 -1.5651,2.21169 0,0 z m 115.5164,79.99386 c -7.0801,-15.34102 9.1334,5.49916 0,0 z m 34.4357,1.41106 c -9.4088,-25.08764 16.1024,-19.59676 0,0 z m 8.3893,-2.34522 c -4.1478,-34.54239 12.6208,1.55819 0,0 z m -207.2103,0.73918 c -0.4305,-4.13934 2.657,3.48821 0,0 z m 331.6698,-1.89595 c 1.5036,-4.72141 1.5036,4.72143 0,0 z m -247.3345,-2.02435 c -0.09,-4.36472 2.1132,0.99466 0,0 z m 247.4543,-0.90873 c -0.5627,-4.53508 1.9194,2.04481 0,0 z m -618.34486,-1.40821 c 2.90195,-8.8086 5.27856,0.90707 0,0 z m 308.11096,-0.71956 c 1.1563,-2.27126 1.1563,2.27123 0,0 z m 313.8611,-0.90171 c 1.5782,-4.12559 0.6445,5.15044 0,0 z m -3.8334,-2.02434 c 1.4274,-1.28306 0.8807,2.19369 0,0 z m -618.79109,-1.41183 c 0.46712,-3.08689 1.06579,3.164 0,0 z m 307.56339,-3.76356 c 1.1572,-4.53921 4.5761,4.63657 0,0 z m 23.4818,0.005 c 1.0755,-2.23978 0.6308,2.19305 0,0 z m 5.0314,-0.34723 c 0.6816,-25.32925 24.1215,5.78169 0,0 z m -335.1679,-1.44803 c -6.69949,-11.41036 8.03676,3.82318 0,0 z m 477.9351,-0.002 c -0.087,-6.77501 4.1037,3.82121 0,0 z m -169.5133,-1.79825 c -2.7719,-4.85353 2.8595,0.99167 0,0 z m -192.13954,-1.51056 c 1.76976,-3.67747 2.30105,2.88823 0,0 z m 501.60014,-1.83442 c 1.4524,-7.78373 0.7416,8.15275 0,0 z m -476.18473,-0.14459 c 2.58534,-3.97495 1.97163,2.20781 0,0 z m -27.57725,-0.22526 1.32365,-1.10963 -1.32365,1.10963 z m 471.95308,-6.84179 c 0.2176,-30.54785 7.3325,22.75324 0,0 z m 7.332,5.08301 c -5.7015,-20.6915 8.0047,-11.32909 0,0 z m -483.21133,-0.18481 c 1.07549,-2.2398 0.63081,2.19303 0,0 z m 490.58523,-0.0534 c -4.8373,-15.58532 8.9744,-15.53621 0,0 z m -320.2496,-1.43022 c 3.1863,-14.69608 13.1395,5.32716 0,0 z m 291.6421,-0.10707 c -5.9883,-26.06545 10.175,-6.01029 0,0 z m 6.9386,0.5273 c -4.2558,-24.91165 10.612,-15.0009 0,0 z m -211.0937,-0.0441 c -0.01,-2.96861 2.197,1.33427 0,0 z m -295.65723,-0.5878 c 0.0454,-2.94664 1.58044,1.98518 0,0 z m 234.82933,-0.37105 c -3.0907,-9.72896 5.2642,3.93777 0,0 z m 258.3047,-0.27368 c -7.0877,-17.21516 10.004,-21.13134 0,0 z m -51.8967,0.045 c -37.8613,-0.57568 -75.8173,-7.67908 -113.5281,-1.2029 7.5304,-23.73876 47.5462,-3.98579 68.5864,-13.38576 15.6672,6.4841 50.421,-7.84237 55.3725,14.58039 l -3.9353,0.45703 -6.4955,-0.44876 0,0 z m -41.4942,-11.69469 c -1.4946,-3.35542 -1.6685,2.7835 0,0 z m -473.31731,11.10492 c -1.11866,-7.63405 6.83852,3.27089 0,0 z m 608.31561,-1.16437 c -0.5295,-3.76293 2.8095,0.95747 0,0 z m -49.1157,-0.64672 c -3.0597,-15.32827 7.1137,-10.58888 0,0 z m -556.32484,-1.08843 c 1.1563,-2.27124 1.1563,2.27125 0,0 z m 619.95124,-0.68409 c -2.6075,-14.30582 3.918,-6.73325 0,0 z m -15.0158,-1.67983 c -0.4151,-4.04737 2.0402,2.22046 0,0 z m -608.51857,-0.41871 c -1.66464,-9.72938 8.6283,2.31196 0,0 z m 309.60307,-0.97353 c 1.8472,-2.33504 0.8305,3.13531 0,0 z m 310.5283,-0.7857 c -0.049,-9.10149 1.4808,6.8199 0,0 z m -10.6286,-2.39872 c 1.0755,-2.23979 0.6308,2.19303 0,0 z m -266.6602,-0.42902 c -8.5231,-6.74526 15.4934,1.32919 0,0 z m -34.0235,-4.03417 c -2.7571,-7.90469 5.001,-0.6765 0,0 z m -303.79837,-0.74226 c 1.1564,-2.27147 1.1564,2.27148 0,0 z m 306.95257,0.0774 c 1.5257,-7.74239 3.2879,2.52403 0,0 z m 311.5133,-2.18801 c -3.4795,-14.85648 4.8925,-0.18694 0,0 z m -157.7369,-0.0476 c -9.0216,-17.44994 9.3214,-22.46309 0,0 z m -151.4458,-0.78409 c 0.4505,-4.42258 3.2854,4.22498 0,0 z m -7.2498,-0.96178 c -7.7886,-23.31795 13.4826,-48.28281 13.5755,-11.25213 0.8637,13.7103 -9.1279,5.67142 -13.5755,11.25213 z m 8.384,-16.77783 c -1.9739,-6.76897 -2.3335,7.34756 0,0 z m 1.0478,-4.56555 c -3.5687,-9.43838 -7.6996,3.8323 0,0 z m -4.6185,-9.1663 c -0.4672,-3.08696 -1.0656,3.16391 0,0 z m 0.7851,30.68841 c 0.7055,-3.10358 1.5651,2.21167 0,0 z m 129.9664,0.12192 c -10.8702,-18.78287 12.8367,-24.6856 0,0 z m 8.2937,0.16708 c -11.4646,-22.7483 11.5294,-20.29901 0,0 z m 5.7631,0.0992 c -7.5421,-25.29653 15.0681,-13.57359 0,0 z m 30.1558,-0.85613 c -1.6074,-14.40931 4.6069,-11.49843 0,0 z m -59.1416,-0.36298 c -11.1604,-25.35882 12.6447,-18.72291 0,0 z m 6.1316,-0.50458 c -8.9843,-26.11419 14.1992,-7.15036 0,0 z m -22.8109,-0.0709 c -8.5389,-25.25949 12.2668,-18.20741 0,0 z m 7.3292,-0.0176 c -7.5903,-29.91542 13.7863,-6.7314 0,0 z m 73.525,-0.34524 c 1.8923,-3.82416 0.746,2.85833 0,0 z m -492.10768,-0.1446 c -0.0904,-4.36473 2.11315,0.99466 0,0 z m 402.78588,-1.7578 c -5.7712,-25.64194 11.7528,-2.65969 0,0 z m 93.4276,0.84615 c -11.9098,-15.19587 7.1064,2.60279 0,0 z m -4.7594,-4.8083 c -2.6307,-21.67145 4.6589,8.57488 0,0 z m 104.9714,0.58306 c -1.7434,-10.40245 4.6902,0.59549 0,0 z m 6.2976,-1.78025 c 3.3735,-6.95872 0.5738,2.88237 0,0 z m 6.5435,0.41033 c 0.6308,-2.19302 1.0755,2.2398 0,0 z m 19.6462,-1.44595 c 0.8364,-3.76807 0.8364,3.76806 0,0 z m -1.7444,-1.52867 c -3.428,-16.72887 7.5142,-1.32265 0,0 z m -17.4424,-1.69092 c 0.1455,-3.43415 3.0374,3.11367 0,0 z m -122.6694,-0.57842 c -0.3124,-3.14895 2.4517,2.69211 0,0 z m 136.3457,0.1093 c 0.746,-4.35196 2.2212,1.27747 0,0 z m -336.3825,-1.55091 c 1.5651,-2.21169 0.7056,3.10359 0,0 z m 213.2339,-2.56858 c 1.1564,-2.27148 1.1564,2.27148 0,0 z m -626.92351,-2.12082 c -0.98185,-4.12488 3.32866,1.55968 0,0 z m 755.34301,-0.73704 c 0.5521,-3.29186 0.9731,2.02927 0,0 z m -751.98747,-1.03232 c -0.11901,-10.27413 5.74479,1.27479 0,0 z m -7.45002,-0.68114 c 0.0169,-5.5068 5.65178,2.39148 0,0 z m 759.45439,-0.62157 c -5.3233,-2.86103 0.7565,-17.91176 0.4029,-5.84988 l -0.4029,5.84988 z m -163.1798,-2.56651 c -7.8481,-17.29686 7.967,-20.89176 0,0 z m 0.2426,-6.12191 c -1.0754,-2.2398 -0.6308,2.19302 0,0 z m -15.8128,4.91624 c -1.4429,-6.47237 5.5672,6.39915 0,0 z m 9.1044,0.57839 c -8.6613,-17.82598 6.3287,-15.49861 0,0 z m -16.1551,-1.43738 c -7.4375,-20.18658 9.5225,-15.96734 0,0 z m -16.1417,-0.12824 c -7.0657,-30.44659 11.4239,-10.72025 0,0 z m 9.7755,0.10034 c -12.0267,-15.32542 9.0372,-22.1036 0,0 z m -18.1289,-4.46323 c -3.2979,-28.00413 10.2233,8.18759 0,0 z m 31.5456,2.74694 c -6.8573,-20.31703 9.734,-5.29231 0,0 z m 45.8382,0.72843 c -5.6794,-24.78089 4.7299,-12.38618 0,0 z m -85.0768,-3.56644 c -3.687,-27.70911 9.7771,3.83825 0,0 z m 80.7389,1.92353 c -8.1606,-18.75108 7.8656,-2.0015 0,0 z m -86.7824,-0.14624 -0.4805,-4.28849 0.4805,4.28849 z m 82.5252,0.12947 c -2.4473,-5.46867 4.3286,-3.79724 0,0 z m 18.0522,-5.28663 c 0.1435,-24.18052 2.6478,14.98975 0,0 z m -4.8146,4.34124 c -3.7946,-16.21596 5.6958,-12.8475 0,0 z m -365.49325,-0.92452 c -0.032,-3.09871 2.48458,0.71472 0,0 z m 380.11265,-1.3755 c -4.1385,-18.39146 5.2902,-11.72638 0,0 z m -370.09625,-0.44994 c 1.15631,-2.27124 1.15631,2.27125 0,0 z m 364.94085,-2.83562 c -3.0046,-17.85293 4.0481,-9.52196 1.3869,1.63559 l -1.3869,-1.63559 z m 9.7059,2.69897 c -5.2429,-19.41067 7.147,-22.31816 0,0 z m 76.592,-0.98561 c 3.1555,-4.41113 -0.8825,3.60152 0,0 z m -457.5427,-0.89757 c 4.24607,-6.3305 -0.17659,5.91928 0,0 z m 450.5712,0.58519 c 0.065,-6.96007 3.7973,1.21107 0,0 z m 39.4622,0.27787 c 1.0755,-2.23978 0.6308,2.19303 0,0 z m -495.75237,-0.79579 c -0.86098,-4.06267 2.93426,1.58073 0,0 z m 392.01047,0.21741 c 0.6308,-2.19303 1.0755,2.23979 0,0 z m -457.58341,-0.74792 c 1.60767,-2.94805 -0.42467,2.46472 0,0 z m 4.04214,-0.6639 c 1.14082,-4.01941 2.22308,3.57214 0,0 z m 556.10007,0.28407 c 1.0658,-4.22879 3.698,2.1964 0,0 z M 358.4134,607.24424 c 0.17882,-5.40737 2.94254,1.09174 0,0 z m 409.69652,-0.68893 c 1.7003,-4.65488 1.278,3.78245 0,0 z m 37.6407,0.0494 c -0.01,-2.96861 2.197,1.33439 0,0 z m 28.5816,-0.16507 c -1.9959,-5.46133 3.7828,3.76075 0,0 z m 49.5152,-0.0877 c -3.2858,-5.85717 4.5574,1.29929 0,0 z m 6.9697,-0.13401 c 0.8845,-1.40487 -0.053,2.65177 0,0 z m -717.34441,-1.05955 c -1.58835,-8.68464 4.30837,3.16812 0,0 z m 512.50801,-0.10121 c -0.4852,-5.37131 2.2756,3.27541 0,0 z m 170.0582,0.34139 c 1.6445,-2.406 1.2394,2.35869 0,0 z m 52.3212,-0.0889 c -4.2386,-16.02999 5.9494,-1.60544 0,0 z m -38.8529,-0.82592 c -0.3474,-3.99689 3.2134,3.87165 0,0 z m -6.7847,-1.77399 c 2.1273,-6.6565 1.0432,5.27177 0,0 z m -90.3,0.37534 c 1.0755,-2.23978 0.6308,2.19304 0,0 z m 103.9815,-0.86756 c 1.1459,-3.19631 1.146,3.19629 0,0 z m -191.4265,-0.27977 c -0.4135,-5.51725 2.3996,1.46446 0,0 z m -333.44973,-1.31083 c -2.3468,-9.77682 4.33845,4.41774 0,0 z m 7.60436,0.72299 c 2.88876,-2.5633 2.88876,2.5633 0,0 z m -10.54191,-0.57839 c 1.07558,-2.23978 0.6309,2.19318 0,0 z m 484.29508,-0.72297 c 3.4349,-5.69392 2.1356,4.67415 0,0 z m 7.5877,-0.28919 c 0.1604,-6.59387 1.7764,3.6392 0,0 z m -34.4703,-3.3739 c 0.8846,-1.405 -0.053,2.65158 0,0 z m 28.7129,0.33738 c 1.1564,-2.27148 1.1564,2.27149 0,0 z m -421.45739,-1.7761 c -0.45528,-3.64835 2.55553,1.48356 0,0 z m -110.42942,-1.37086 c 0.70558,-3.10354 1.56513,2.21168 0,0 z m 1.66224,-1.50913 c -0.52462,-3.21023 2.42086,1.51078 0,0 z m 433.43067,-5.19642 c 2.6186,-25.48403 3.2187,18.36073 0,0 z m 7.4316,4.50248 c -5.1562,-15.94128 8.0076,-6.28565 0,0 z m 162.5408,-1.41669 c 0.036,-14.83751 5.0597,5.70653 0,0 z m -184.7915,0.16682 c -8.6952,-27.08547 12.1664,-3.19392 0,0 z m 44.8399,-0.0331 c -0.044,-3.88532 1.8796,3.11846 0,0 z m -363.04895,-0.30771 c 1.15631,-2.27125 1.15631,2.27123 0,0 z m 371.92815,-1.73515 c 0.7797,-8.15152 1.4762,7.83256 0,0 z m -471.7968,1.23439 c -1.4883,-2.8029 1.86652,0.5703 0,0 z m 404.277,-0.61867 c -8.5844,-9.6985 6.4516,-15.10227 0,0 z m 6.4124,0.0617 c -4.329,-10.67627 7.7335,-10.97617 0,0 z m 15.7386,0.51203 c -8.194,-12.04839 8.8524,-12.57024 0,0 z m -31.2663,-0.44088 c -7.8232,-20.90152 9.3003,-13.10151 0,0 z m 71.9286,-0.46375 c -2.2697,-14.54875 4.383,3.49562 0,0 z M 413.29686,587.5358 c -6.35583,-6.04047 8.35524,2.0505 0,0 z m -185.21964,-0.3564 c 1.73452,-3.40701 1.73452,3.40704 0,0 z m 463.9633,-0.10089 c -3.5855,-14.8797 5.0657,-20.74461 0,0 z m -322.60608,-0.76668 c 1.15631,-2.27124 1.15631,2.27125 0,0 z m 412.13248,-0.8093 c -3.2703,-8.88151 4.5701,-2.02053 0,0 z m -579.36528,0.01 2.37484,-0.27169 -2.37484,0.27169 z m 482.71488,-0.80329 c -6.8354,-9.80793 7.2705,2.12993 0,0 z m 91.6985,-1.01738 c -1.7644,-16.34963 4.5086,5.51095 0,0 z m 9.7036,-1.64476 c -2.8604,-25.6179 2.9697,7.83797 0,0 z m 123.1486,1.95203 c 1.1563,-2.27123 1.1563,2.27126 0,0 z m -118.1674,-1.49675 c -4.7927,-10.12857 4.6101,-5.0857 0,0 z m -22.6729,-0.57577 c 0.8845,-1.40492 -0.053,2.65174 0,0 z m 3.8103,0.0696 c -2.424,-6.68373 3.6427,1.33005 0,0 z m 23.465,-0.0213 c 1.1459,-3.19615 1.1459,3.19611 0,0 z m -381.68439,-0.90605 1.12997,-0.67408 -1.12997,0.67408 z m 441.38169,-0.4623 c -1.4883,-2.80289 1.8665,0.57034 0,0 z m -655.51441,-0.57837 c -1.48831,-2.80291 1.86651,0.57033 0,0 z m 20.37966,-0.57352 c -1.3232,-9.95899 2.69678,4.29398 0,0 z m 580.70845,0.0674 c -3.2138,-12.03072 2.53,-11.11676 0,0 z m -593.70067,-0.47314 c 1.56513,-2.21164 0.70557,3.10357 0,0 z m 478.21897,-0.25506 0.6096,-0.13447 -0.6096,0.13447 z m -461.2082,0 c 1.76469,-2.49175 2.31343,2.57654 0,0 z m 659.8924,-0.28586 c 1.6647,-2.59875 -0.1646,2.91736 0,0 z m -687.92421,-0.65253 c 1.30656,-1.96884 1.49161,3.6114 0,0 z m 38.3342,0.36001 c 1.1564,-2.27147 1.1564,2.27149 0,0 z m 127.46111,0 c 1.23936,-2.35868 1.64452,2.406 0,0 z m 54.23717,-0.42714 c 1.98125,-5.13118 1.58497,3.26337 0,0 z m 493.13303,0.55112 c -6.8945,-11.91274 4.3686,-5.09117 0,0 z m -179.0426,-0.50957 c -1.7477,-2.54967 2.1961,0.3723 0,0 z m 75.1714,-0.15283 c 0.045,-2.94661 1.5804,1.9852 0,0 z m -598.44648,-0.90815 c 0.46702,-3.08703 1.06588,3.16389 0,0 z m 104.6339,0.0682 c 0.18771,-3.92702 1.98453,2.0724 0,0 z m 522.40748,0.13156 c 1.9817,-3.65129 2.1052,2.60178 0,0 z m -606.50311,-0.48903 c 1.07549,-2.23978 0.63081,2.19303 0,0 z m 613.46671,-0.22674 c -3.042,-9.64821 5.0182,0.83606 0,0 z m 13.5367,-0.34674 c 2.1349,-6.59229 1.1085,4.70867 0,0 z m -621.6426,0.19995 c -2.58169,-4.43522 4.35964,0.006 0,0 z m 2.62504,-0.8634 c 1.2859,-4.38994 1.32533,4.06449 0,0 z m 627.15926,0.36299 c -0.2663,-3.0383 3.0303,2.47962 0,0 z m -636.98198,-0.0901 c -1.12943,-3.45892 2.86563,1.36343 0,0 z m 569.71318,-0.52928 c -3.739,-15.31645 4.9203,1.0634 0,0 z m -485.14261,-0.82028 c 0.4155,-2.63244 0.4155,2.63247 0,0 z m -140.45929,-1.87992 c 1.26606,-9.51994 1.08661,7.36737 0,0 z m 257.11032,1.97147 c -0.38363,-3.8977 3.89323,0.94373 0,0 z m 405.68108,-0.18109 c 1.6253,-2.98942 1.6614,2.46393 0,0 z m 15.3249,-0.0263 c -1.8723,-5.63278 4.997,2.26972 0,0 z m -652.97478,-0.4627 c 1.35009,-2.47986 2.09242,2.55358 0,0 z m 9.08885,-0.63761 c 2.77493,-12.64307 2.6731,5.2975 0,0 z m 7.4428,0.63761 c 1.64452,-2.40596 1.23936,2.35868 0,0 z m 7.4477,0.04 c 0.21095,-3.17015 1.84114,2.2606 0,0 z m 151.3737,-0.0903 c 0.16627,-4.55428 2.86536,2.5796 0,0 z m 484.24173,0.19499 c 0.1758,-4.38287 2.5796,1.27554 0,0 z m -632.0421,-0.93198 c 3.02932,-2.66296 1.51716,3.18864 0,0 z m 15.81291,0.20899 c 2.27505,-2.5684 2.97706,2.65008 0,0 z m 83.37679,-0.0342 c 1.42743,-1.28305 0.88074,2.19371 0,0 z m -121.23186,-0.49694 c 0.56921,-6.98764 3.40102,1.97308 0,0 z m 29.10954,-0.71121 c 4.40039,-2.93051 -0.21265,3.38133 0,0 z m 135.76552,0.73235 c -6.6153,-4.62697 9.83392,2.1169 0,0 z m 425.3195,0.13398 c -2.6376,-3.95769 2.8607,-1.05556 0,0 z m -581.56937,-0.7808 c 1.15632,-2.27125 1.15632,2.27124 0,0 z m 96.40453,-0.0362 c 1.11625,-3.53337 1.77937,2.22313 0,0 z m -87.1098,-0.88515 c 4.1971,-13.09283 7.41147,1.29662 0,0 z m 17.12283,0.14511 c -0.99058,-3.84136 3.14076,3.26762 0,0 z m 605.49751,-0.20089 c -3.7421,-4.84274 4.5403,1.30349 0,0 z M 197.17026,570.1172 c 1.35007,-2.47989 2.09241,2.55357 0,0 z m 113.48,-0.40269 c -6.40434,-4.11422 4.6126,0.72606 0,0 z m 103.43237,-0.4954 c 1.42716,-3.67396 1.60011,3.42962 0,0 z m -87.1973,-0.86335 c -0.76645,-5.65932 4.27392,4.22236 0,0 z m 7.68901,0.47717 c -4.25265,-4.04907 4.50765,1.28508 0,0 z m 6.82829,0.12754 c 1.07549,-2.23979 0.6308,2.19302 0,0 z m 506.72999,0.0358 c 2.3416,-2.09676 2.2772,2.31328 0,0 z m -528.53255,-0.5531 c 2.87764,-1.98615 2.85068,2.18654 0,0 z m 108.29401,-0.0612 c 1.15632,-2.27125 1.15632,2.27124 0,0 z m -183.44917,-1.15676 c 0.4154,-2.63242 0.4154,2.63244 0,0 z m 93.10943,0.54934 c -0.52471,-3.21036 2.4205,1.51076 0,0 z m 496.20288,0.029 c 1.2393,-2.35875 1.6446,2.40608 0,0 z m -438.92634,-0.55803 c 1.65966,-3.82399 3.46298,1.12255 0,0 z m -63.49103,-0.59873 c 1.07567,-2.23987 0.63089,2.1931 0,0 z m 9.14804,0.0852 c 0.48936,-7.91462 2.97172,1.94653 0,0 z m 460.20613,-0.40855 c 1.5119,-2.12336 0.1689,2.95415 0,0 z m -611.90935,-0.83343 c 2.55268,-5.14266 1.95792,3.95358 0,0 z m 178.50164,0.0109 c -1.58641,-7.8684 5.00405,4.62123 0,0 z m 363.26641,0.73427 c -2.2016,-7.42532 7.9184,-1.86082 0,0 z M 171.74888,564.7421 c -0.39065,-5.888 3.19167,2.2359 0,0 z m 163.9758,-0.10109 c 0.32942,-4.49894 2.0294,2.97775 0,0 z m 402.83764,0.0188 c -4.2668,-16.54631 6.0818,-8.9592 0,0 z m 6.9907,0.22524 c -5.725,-14.48809 8.0634,-3.05277 0,0 z m 162.3297,0.1712 c -4.0548,-16.05677 7.123,-0.68235 0,0 z m -494.36395,-0.723 c 1.23935,-2.35869 1.64451,2.406 0,0 z m -269.61701,-0.84194 c 0.95666,-2.16301 0.33004,3.08056 0,0 z m 180.7345,0.27317 c -9.37998,-0.24543 4.0102,-2.57834 0,0 z m 94.63263,0.0588 c 0.4478,-2.85542 1.8002,1.11576 0,0 z m 3.0634,-0.40476 c 1.89625,-5.29204 2.75847,3.0483 0,0 z m -241.9332,-0.24189 c 2.09223,-2.55353 1.35,2.47985 0,0 z m 152.13873,-0.54424 c -3.59194,-6.65213 3.37316,2.89586 0,0 z m -145.14711,-0.2599 c -9.52338,-0.66864 2.69989,-5.12546 0,0 z m 229.49196,-0.0774 c 2.21497,-2.91322 -0.73825,2.94601 0,0 z m 355.89925,0.54785 c -2.018,-3.61538 2.3097,-1.67961 0,0 z m -49.9592,-0.83273 c -0.5901,-13.48783 7.0062,2.45459 0,0 z m -549.08584,-0.47835 c -0.032,-3.09873 2.4846,0.7147 0,0 z m 15.86169,0.0542 c -4.61973,-11.26285 6.63959,0.60475 0,0 z m -11.83493,-0.36297 1.16957,-1.08819 -1.16957,1.08819 z m 246.78354,-1.37218 c 0.1604,-6.59388 1.77635,3.6392 0,0 z m 305.74954,0.78372 c -3.8091,-16.93594 7.9726,-2.95409 0,0 z m 51.2301,-0.0266 c 0.7056,-3.10359 1.5652,2.21168 0,0 z m -460.3099,-1.1718 c 0.0992,-5.18056 3.66786,2.89165 0,0 z m 455.4176,-0.87327 c -0.2417,-8.07869 1.9243,6.28532 0,0 z m -452.02282,0.52645 c -0.31243,-3.14893 2.45147,2.69213 0,0 z m 69.29866,-0.29891 c 0.88448,-1.40493 -0.0525,2.65157 0,0 z m 19.92519,-0.86733 c -1.81703,-5.56349 5.20245,2.59788 0,0 z m -236.59698,-0.30796 c -0.48946,-3.05374 3.25967,3.75929 0,0 z m 604.04875,-0.22248 c 1.5126,-2.51975 0.7374,2.38855 0,0 z m -364.66358,-0.59731 c 0.2842,-5.96867 8.29791,4.35695 0,0 z m 374.00758,0.0188 c 1.1564,-2.27149 1.1564,2.27147 0,0 z m -598.97158,-0.57839 c 1.23936,-2.35868 1.64452,2.40601 0,0 z m 206.76495,0 c 0.63081,-2.19303 1.07549,2.23979 0,0 z m 511.35433,-0.27066 c -0.078,-4.02139 1.5273,2.95425 0,0 z m -483.0829,-0.30765 c 0.6309,-2.19309 1.07567,2.23986 0,0 z m 318.4134,-0.24678 c 2.1562,-3.61452 2.1509,3.07994 0,0 z M 173.451,554.85184 c 2.38106,-5.64116 2.25975,3.38402 0,0 z m -4.45933,-0.14256 1.32373,-1.10961 -1.32373,1.10961 z m 93.96017,-1.15159 c 4.5559,-21.34386 1.25885,5.42865 0,0 z m 157.26473,-0.35829 c -28.09902,-13.80049 14.51355,-25.29613 2.7582,-8.89368 -18.97947,-6.09027 5.926,5.59879 -2.7582,8.89368 z m -87.49041,-0.77029 c 0.91403,-7.95571 3.70979,2.7407 0,0 z m 453.11336,0.3365 c 1.2394,-2.35869 1.6445,2.406 0,0 z m -627.48259,-0.49144 c -8.68217,-4.63876 8.60383,0.54507 0,0 z m 7.30742,0.0318 c -5.11274,-3.35832 5.69788,0.87756 0,0 z m 630.23787,-1.30977 c 1.6003,-3.16326 0.6448,4.11295 0,0 z m -627.72214,0.0342 c 1.15641,-2.27148 1.15641,2.27148 0,0 z m 79.30376,-0.57839 c 0.63089,-2.19317 1.07558,2.23979 0,0 z m 22.14141,-1.01217 c -0.47308,-8.329 2.53461,6.0678 0,0 z m 154.91464,0.0607 c -2.86981,-8.59 4.17414,3.15927 0,0 z m -162.92033,-0.13706 c 0.4478,-2.85543 1.80019,1.11576 0,0 z m 586.51306,-0.88765 c 1.4153,-5.33612 1.7816,4.68521 0,0 z m 61.6237,0.58322 c -6.081,-2.91503 3.2266,-4.3647 0,0 z m -114.0813,-1.64358 c 1.5938,-8.91159 0.8728,6.83442 0,0 z m 59.4655,1.47003 c -0.3783,-3.04624 4.4907,1.08444 0,0 z m 14.7946,-0.74705 c -0.1436,-5.50022 2.7092,2.34321 0,0 z m -79.4972,-0.48803 c -0.032,-3.09877 2.4847,0.7147 0,0 z m -4.5984,-1.24712 c 1.1564,-2.27148 1.1564,2.27147 0,0 z m -358.18504,-0.57835 c 1.07566,-2.23986 0.63089,2.1931 0,0 z m 373.04684,-1.01217 c 0.7225,-6.48699 2.186,1.6459 0,0 z m -651.2092,-2.71321 c 2.16023,-6.72505 5.918,3.43827 0,0 z m -5.43068,-0.13053 c -2.27621,-6.50872 2.02316,-0.49263 0,0 z m 281.73623,-0.0758 c -0.21344,-6.33626 3.15348,2.55994 0,0 z m 483.90915,-0.11698 c 1.0755,-2.23978 0.6308,2.19304 0,0 z m -164.27,-0.95433 c -3.6881,-4.07818 3.644,-0.89343 0,0 z m -20.932,-2.15932 c -6.6259,-13.135 5.3716,-17.61442 0,0 z m 14.0843,-0.11444 c -6.0061,-11.34853 5.8245,0.82387 0,0 z m 170.382,-1.73612 c -2.1957,-13.79601 4.721,9.3447 0,0 z m -764.90968,1.68671 c -0.69996,-3.65536 5.02,2.20262 0,0 z m 277.19786,-3.04151 c 7.89577,0.71632 1.41773,-3.32715 0,0 z m 310.91232,1.36876 c 1.5118,-2.12328 0.169,2.95409 0,0 z m 12.7773,-0.9338 c -0.5333,-8.80553 4.2111,6.93945 0,0 z m -601.20693,-0.223 c 1.5119,-2.12336 0.16894,2.95415 0,0 z m 256.83903,0.38521 c 2.98161,-3.02665 2.51671,2.53064 0,0 z m 5.2709,-0.69058 c 3.29857,-2.41668 4.02809,1.99899 0,0 z m 325.2017,-1.49204 c -5.0199,-11.34098 4.9396,-2.39633 0,0 z m 41.3689,-1.67287 c 1.5783,-4.12569 0.6444,5.15042 0,0 z m -33.6614,-0.59786 c 1.001,-8.00137 3.125,-0.42576 0,0 z m 171.0049,-4.59582 c -1.5203,-4.35559 1.8239,2.40173 0,0 z m -1.4304,-4.02632 c -1.4952,-12.35867 5.662,2.22985 0,0 z m -117.7043,-0.28919 c 1.1564,-2.27148 1.1564,2.27148 0,0 z m 9.8021,-1.19772 c -0.4552,-3.64834 2.5555,1.48355 0,0 z m 48.5259,-5.32266 c -1.0744,-4.24455 2.8217,1.20098 0,0 z m -48.4652,-0.92097 c -1.4883,-2.8029 1.8665,0.57034 0,0 z m 109.1799,-3.48389 c -3.3167,-5.19375 2.8179,-11.3247 0,0 z m -179.5788,-0.44962 c -2.4625,-17.61758 5.0915,-0.53743 0,0 z m 8.3058,-0.48198 c 1.1707,-4.23673 2.6897,3.41741 0,0 z m 6.4832,-0.2611 c -0.9129,-4.71729 4.7185,1.12518 0,0 z m -22.2961,-0.53821 c 0.4478,-2.85544 1.8002,1.11574 0,0 z m 15.0915,-1.80859 c -0.7929,-7.52753 4.9533,0.10443 0,0 z m -13.947,-1.14 c -6.1442,-7.39401 5.5633,0.95298 0,0 z m 184.8917,-12.05084 c -5.8166,-15.76308 4.3251,-46.44705 1.1954,-12.92502 -0.7163,3.45079 2.3219,10.75759 -1.1954,12.92502 z m -127.3166,-0.0668 c 0.045,-2.94665 1.5805,1.98525 0,0 z m 13.6361,-0.8734 c 1.6984,-4.91838 1.0452,3.14794 0,0 z m 0.2793,-4.87276 c -1.4885,-2.80278 1.8666,0.57006 0,0 z m -57.7805,-2.39116 c 1.0755,-2.23979 0.6308,2.19304 0,0 z m 103.0231,0 c 1.2393,-2.35876 1.6445,2.40607 0,0 z m -101.5856,-1.10857 c -1.6848,-7.14327 3.5652,5.98533 0,0 z m -15.3337,-2.69912 c 1.6802,-2.78179 1.4518,3.39529 0,0 z m 6.2671,-0.57839 c 0.8846,-1.40496 -0.053,2.65161 0,0 z m 15.296,-1.17938 c 1.1281,-3.95632 0.5837,4.93174 0,0 z m -13.0928,0.50461 c -4.4263,-10.31629 4.0692,-0.11574 0,0 z m -301.80387,-0.4305 c -2.1679,-10.76105 4.40494,1.21071 0,0 z m 292.37527,-0.61581 c 1.512,-2.12339 0.169,2.95426 0,0 z m 16.6115,0.51613 c -0.6834,-5.95913 -3.6307,0.1075 0,0 z m -16.3051,-3.48601 c -1.4552,-2.8292 3.4299,-0.0239 0,0 z m -301.6224,-1.41943 c 1.69125,-7.24379 3.19656,4.45322 0,0 z m 308.5037,0.0856 c 1.1564,-2.27148 1.1564,2.27148 0,0 z m -304.75679,-2.33216 c -3.80797,-8.54056 8.10654,3.21374 0,0 z m 6.70848,-0.55976 c 1.07549,-2.23978 0.6308,2.19303 0,0 z m -2.15632,-4.04868 c 1.07567,-2.23986 0.63088,2.19309 0,0 z m 6.2313,-1.1529 c 1.49081,-1.94692 4.06832,2.68015 0,0 z m -10.48396,-1.04364 c -6.75031,-8.93273 5.00834,-2.57887 0,0 z m 4.49226,-0.0404 c 0.52694,-7.8267 3.99987,-0.0571 0,0 z m 365.73813,-1.85251 c 0.4587,-8.11306 0.9909,7.16933 0,0 z m -359.02964,-0.82681 c 1.14589,-3.19611 1.14589,3.19614 0,0 z m 302.60044,-1.44595 c 0.6308,-2.19303 1.0755,2.23978 0,0 z m -1.4068,-2.72238 c -0.4251,-2.53022 1.6008,3.00215 0,0 z M 436.51928,457.9109 c 1.23935,-2.35867 1.64452,2.40602 0,0 z m 294.21484,-0.61251 c 1.4276,-1.2832 0.8808,2.19397 0,0 z m 8.146,0.0342 c 1.1563,-2.27124 1.1563,2.27125 0,0 z m -288.46465,-1.19095 c 1.42734,-1.28309 0.88065,2.19379 0,0 z m -10.92527,-0.65991 c -1.42155,-8.49254 6.41548,2.52071 0,0 z m -8.51419,-3.0228 c -1.18889,-5.59088 6.49619,1.9975 0,0 z m 6.02249,-0.33182 c 1.64444,-2.40599 1.23927,2.35866 0,0 z m 2.39584,-1.31236 c -10.18578,-12.83775 7.28945,-4.77378 0,0 z m 346.44518,-3.60389 c 1.1459,-3.19632 1.146,3.19628 0,0 z m -343.57011,-5.15729 c -6.61396,-11.36894 6.85962,-13.93395 0,0 z m 347.89001,0.38559 c 0.1757,-4.38287 2.5796,1.27551 0,0 z m -337.54143,-0.63262 c -0.032,-3.09878 2.48467,0.71471 0,0 z m -7.95265,-1.24712 c 1.2488,-4.04981 2.50969,4.57901 0,0 z m 3.6765,-1.19684 c -12.59979,-6.42032 11.67097,-0.004 0,0 z m 9.26125,-2.27346 c 1.1564,-2.27148 1.1564,2.27148 0,0 z m -9.82316,-1.73515 c 1.733,-2.43769 1.733,2.4377 0,0 z m 6.23415,-0.56895 c -0.41335,-5.51737 2.39967,1.46465 0,0 z m 9.32196,-2.2279 c 2.66874,-3.98245 -1.26543,3.45571 0,0 z m -15.74231,-0.88507 c -1.57083,-5.99025 4.39319,1.40277 0,0 z m 11.66064,0.16122 c -0.41504,-4.04738 2.04017,2.2205 0,0 z m -5.72431,-0.52797 c 1.07549,-2.23979 0.6308,2.19302 0,0 z m -9.82308,-1.76387 c 0.44416,-10.90595 3.93587,2.02151 0,0 z m 5.63033,-3.08167 c -2.00002,-4.0736 6.30305,3.24254 0,0 z m 9.46374,-3.83021 c 1.11189,-2.48125 2.28023,3.41019 0,0 z m -10.18257,-0.72297 c 2.02271,-3.01298 2.02271,3.01297 0,0 z m 7.20569,-2.63228 c -2.56354,-5.90465 4.62977,0.64342 0,0 z m -8.02857,-1.47564 c -5.45578,-17.66028 6.40309,2.44379 0,0 z m 4.29697,0.20384 c 0.73735,-2.38855 1.51253,2.51975 0,0 z m -1.15284,-3.6149 c 0.95435,-8.70618 4.82275,3.14654 0,0 z m 6.66336,0.54341 c -8.63009,-6.36061 5.39579,-2.44525 0,0 z m -9.56833,-4.88128 c 1.59423,-5.99252 3.46733,0.48169 0,0 z m 6.69326,-0.71526 c -6.73296,-3.14611 5.37051,-2.18603 0,0 z m 6.95291,-0.57667 c -0.46017,-5.45633 2.46998,1.42587 0,0 z m -7.09176,-4.05811 c -10.30274,-3.66897 15.23532,-3.91873 0,0 z m 365.25245,-0.0437 c 1.6548,-6.96399 7.018,4.59964 0,0 z m -347.8632,-1.40221 c 1.7345,-3.40704 1.7345,3.40701 0,0 z m -5.271,-0.86759 c 1.73299,-2.43765 1.73299,2.43769 0,0 z m -5.27091,-3.14697 c 0.70557,-3.10369 1.56521,2.21183 0,0 z m 11.32749,0.43215 c -1.45502,-2.82919 3.42976,-0.0239 0,0 z m -16.42519,-1.04466 c -8.23863,-2.57794 4.36355,-11.63473 0,0 z m 2.22264,-0.86756 c 1.15639,-2.27148 1.15639,2.27148 0,0 z m 3.91948,-1.83285 c 5.96295,-2.97178 -3.6351,4.05925 0,0 z m -3.43296,-1.95556 2.49962,-1.96537 -2.49962,1.96537 z m 5.2636,-0.21786 c 0.91288,-6.84685 3.59995,4.55267 0,0 z m -18.20874,-1.77756 c -0.83036,-1.7795 2.09668,1.10923 0,0 z m 31.62571,0 c 1.07549,-2.23979 0.6308,2.19302 0,0 z m 1.43749,0.35107 1.42182,-0.32217 -1.42182,0.32217 z m 4.79177,-0.33584 1.62744,0.0379 -1.62744,-0.0379 z m 2.39593,-0.0152 c 1.07549,-2.23979 0.63081,2.19303 0,0 z m -11.11093,-0.39509 0.86561,0.10678 -0.86561,-0.10678 z"
+       id="path3569"
+       inkscape:connector-curvature="0"
+       inkscape:export-filename="/home/cats/Desktop/pyohio.png"
+       inkscape:export-xdpi="71.95591"
+       inkscape:export-ydpi="71.95591" />
+    <path
+       inkscape:connector-curvature="0"
+       id="rect4739"
+       d="m 140.98827,675.68522 771.03079,0 0,299.75116 -771.03079,0 z"
+       style="fill:url(#linearGradient4072);fill-opacity:1;fill-rule:evenodd;stroke:none"
+       sodipodi:nodetypes="ccccc"
+       inkscape:export-filename="/home/cats/Desktop/pyohio.png"
+       inkscape:export-xdpi="71.95591"
+       inkscape:export-ydpi="71.95591" />
     <g
-       transform="matrix(0.70248061,0,0,1.2531986,263.96372,41.528369)"
-       style="font-size:32px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-align:center;line-height:100%;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke:none;font-family:Bitstream Vera Sans;-inkscape-font-specification:Bitstream Vera Sans"
-       id="titlebox">
-      <path
-         d="m 99.59375,123.9074 3.17188,0 0,14.17188 c -1e-5,2.50001 0.45311,4.30209 1.35937,5.40625 0.90624,1.09375 2.37499,1.64063 4.40625,1.64062 2.02082,1e-5 3.48436,-0.54687 4.39063,-1.64062 0.90623,-1.10416 1.35935,-2.90624 1.35937,-5.40625 l 0,-14.17188 3.17188,0 0,14.5625 c -3e-5,3.04168 -0.75523,5.33855 -2.26563,6.89063 -1.50002,1.55208 -3.71876,2.32812 -6.65625,2.32812 -2.94793,0 -5.17709,-0.77604 -6.6875,-2.32812 -1.5,-1.55208 -2.250003,-3.84895 -2.25,-6.89063 l 0,-14.5625"
-         id="path3304"
-         inkscape:connector-curvature="0" />
-      <path
-         d="m 134.45312,136.29803 c 0.67707,0.22918 1.33332,0.71876 1.96875,1.46875 0.64582,0.75001 1.29165,1.78126 1.9375,3.09375 l 3.20313,6.375 -3.39063,0 -2.98437,-5.98438 c -0.77085,-1.56249 -1.52085,-2.59895 -2.25,-3.10937 -0.71876,-0.51041 -1.70314,-0.76562 -2.95313,-0.76563 l -3.43749,0 0,9.85938 -3.15625,0 0,-23.32813 7.12499,0 c 2.66666,3e-5 4.65624,0.55732 5.96875,1.67188 1.31249,1.1146 1.96874,2.79689 1.96875,5.04687 -1e-5,1.46877 -0.34376,2.68752 -1.03125,3.65625 -0.67709,0.96877 -1.66668,1.64064 -2.96875,2.01563 m -7.90624,-9.79688 0,8.28125 3.96874,0 c 1.52083,2e-5 2.66666,-0.34894 3.4375,-1.04687 0.78124,-0.70832 1.17187,-1.74478 1.17188,-3.10938 -1e-5,-1.36456 -0.39064,-2.3906 -1.17188,-3.07812 -0.77084,-0.6979 -1.91667,-1.04686 -3.4375,-1.04688 l -3.96874,0"
-         id="path3306"
-         inkscape:connector-curvature="0" />
-      <path
-         d="m 158.98437,126.50115 0,18.14063 3.8125,0 c 3.21874,0 5.57291,-0.72916 7.0625,-2.1875 1.49999,-1.45833 2.24999,-3.76041 2.25,-6.90625 -1e-5,-3.12499 -0.75001,-5.41144 -2.25,-6.85938 -1.48959,-1.45831 -3.84376,-2.18748 -7.0625,-2.1875 l -3.8125,0 m -3.15625,-2.59375 6.48438,0 c 4.52082,3e-5 7.83852,0.94273 9.95312,2.82813 2.11457,1.87502 3.17186,4.81251 3.17188,8.8125 -2e-5,4.02084 -1.06252,6.97396 -3.1875,8.85937 -2.12502,1.88542 -5.43751,2.82813 -9.9375,2.82813 l -6.48438,0 0,-23.32813"
-         id="path3308"
-         inkscape:connector-curvature="0" />
-      <path
-         d="m 189.92187,126.04803 c -2.29167,2e-5 -4.11459,0.85419 -5.46875,2.5625 -1.34375,1.70835 -2.01563,4.03647 -2.01562,6.98437 -1e-5,2.93751 0.67187,5.26043 2.01562,6.96875 1.35416,1.70834 3.17708,2.56251 5.46875,2.5625 2.29166,1e-5 4.10415,-0.85416 5.4375,-2.5625 1.34374,-1.70832 2.01561,-4.03124 2.01563,-6.96875 -2e-5,-2.9479 -0.67189,-5.27602 -2.01563,-6.98437 -1.33335,-1.70831 -3.14584,-2.56248 -5.4375,-2.5625 m 0,-2.5625 c 3.27082,2e-5 5.8854,1.09898 7.84375,3.29687 1.95832,2.18752 2.93748,5.12502 2.9375,8.8125 -2e-5,3.67709 -0.97918,6.61459 -2.9375,8.8125 -1.95835,2.1875 -4.57293,3.28125 -7.84375,3.28125 -3.28125,0 -5.90625,-1.09375 -7.875,-3.28125 -1.95833,-2.18749 -2.9375,-5.12499 -2.9375,-8.8125 0,-3.68748 0.97917,-6.62498 2.9375,-8.8125 1.96875,-2.19789 4.59375,-3.29685 7.875,-3.29687"
-         id="path3310"
-         inkscape:connector-curvature="0" />
-      <path
-         d="m 205.64062,123.9074 3.15625,0 0,23.32813 -3.15625,0 0,-23.32813"
-         id="path3312"
-         inkscape:connector-curvature="0" />
-      <path
-         d="m 215.07812,123.9074 4.25,0 10.34375,19.51563 0,-19.51563 3.0625,0 0,23.32813 -4.25,0 -10.34375,-19.51563 0,19.51563 -3.0625,0 0,-23.32813"
-         id="path3314"
-         inkscape:connector-curvature="0" />
-      <path
-         d="m 254.92187,143.9074 0,-6.26562 -5.15625,0 0,-2.59375 8.28125,0 0,10.01562 c -1.21877,0.86459 -2.56251,1.52084 -4.03125,1.96875 -1.46876,0.4375 -3.03647,0.65625 -4.70312,0.65625 -3.64584,0 -6.50001,-1.0625 -8.5625,-3.1875 -2.05209,-2.13541 -3.07813,-5.10416 -3.07813,-8.90625 0,-3.81248 1.02604,-6.78123 3.07813,-8.90625 2.06249,-2.13539 4.91666,-3.2031 8.5625,-3.20312 1.52082,2e-5 2.96353,0.18752 4.32812,0.5625 1.37499,0.37502 2.64061,0.9271 3.79688,1.65625 l 0,3.35937 c -1.16669,-0.98956 -2.40627,-1.73435 -3.71875,-2.23437 -1.31252,-0.49998 -2.69272,-0.74998 -4.14063,-0.75 -2.85417,2e-5 -5,0.79689 -6.4375,2.39062 -1.42708,1.59377 -2.14063,3.96877 -2.14062,7.125 -1e-5,3.14585 0.71354,5.51563 2.14062,7.10938 1.4375,1.59375 3.58333,2.39063 6.4375,2.39062 1.11457,1e-5 2.10936,-0.0937 2.98438,-0.28125 0.87498,-0.19791 1.66144,-0.49999 2.35937,-0.90625"
-         id="path3316"
-         inkscape:connector-curvature="0" />
-      <path
-         d="m 274.01562,123.9074 3.15625,0 0,23.32813 -3.15625,0 0,-23.32813"
-         id="path3318"
-         inkscape:connector-curvature="0" />
-      <path
-         d="m 280.21875,123.9074 19.73437,0 0,2.65625 -8.28125,0 0,20.67188 -3.17187,0 0,-20.67188 -8.28125,0 0,-2.65625"
-         id="path3320"
-         inkscape:connector-curvature="0" />
-      <path
-         d="m 311.125,123.9074 3.1875,0 4.90625,19.71875 4.89062,-19.71875 3.54688,0 4.90625,19.71875 4.89062,-19.71875 3.20313,0 -5.85938,23.32813 -3.96875,0 -4.92187,-20.25 -4.96875,20.25 -3.96875,0 -5.84375,-23.32813"
-         id="path3322"
-         inkscape:connector-curvature="0" />
-      <path
-         d="m 355.89062,136.29803 c 0.67707,0.22918 1.33332,0.71876 1.96875,1.46875 0.64582,0.75001 1.29165,1.78126 1.9375,3.09375 l 3.20313,6.375 -3.39063,0 -2.98437,-5.98438 c -0.77085,-1.56249 -1.52085,-2.59895 -2.25,-3.10937 -0.71876,-0.51041 -1.70314,-0.76562 -2.95313,-0.76563 l -3.4375,0 0,9.85938 -3.15625,0 0,-23.32813 7.125,0 c 2.66666,3e-5 4.65624,0.55732 5.96875,1.67188 1.31249,1.1146 1.96874,2.79689 1.96875,5.04687 -1e-5,1.46877 -0.34376,2.68752 -1.03125,3.65625 -0.67709,0.96877 -1.66668,1.64064 -2.96875,2.01563 m -7.90625,-9.79688 0,8.28125 3.96875,0 c 1.52083,2e-5 2.66666,-0.34894 3.4375,-1.04687 0.78124,-0.70832 1.17187,-1.74478 1.17188,-3.10938 -10e-6,-1.36456 -0.39064,-2.3906 -1.17188,-3.07812 -0.77084,-0.6979 -1.91667,-1.04686 -3.4375,-1.04688 l -3.96875,0"
-         id="path3324"
-         inkscape:connector-curvature="0" />
-      <path
-         d="m 376.54687,126.04803 c -2.29167,2e-5 -4.11459,0.85419 -5.46875,2.5625 -1.34375,1.70835 -2.01563,4.03647 -2.01562,6.98437 -10e-6,2.93751 0.67187,5.26043 2.01562,6.96875 1.35416,1.70834 3.17708,2.56251 5.46875,2.5625 2.29166,1e-5 4.10415,-0.85416 5.4375,-2.5625 1.34374,-1.70832 2.01561,-4.03124 2.01563,-6.96875 -2e-5,-2.9479 -0.67189,-5.27602 -2.01563,-6.98437 -1.33335,-1.70831 -3.14584,-2.56248 -5.4375,-2.5625 m 0,-2.5625 c 3.27082,2e-5 5.8854,1.09898 7.84375,3.29687 1.95832,2.18752 2.93748,5.12502 2.9375,8.8125 -2e-5,3.67709 -0.97918,6.61459 -2.9375,8.8125 -1.95835,2.1875 -4.57293,3.28125 -7.84375,3.28125 -3.28125,0 -5.90625,-1.09375 -7.875,-3.28125 -1.95833,-2.18749 -2.9375,-5.12499 -2.9375,-8.8125 0,-3.68748 0.97917,-6.62498 2.9375,-8.8125 1.96875,-2.19789 4.59375,-3.29685 7.875,-3.29687"
-         id="path3326"
-         inkscape:connector-curvature="0" />
-      <path
-         d="m 392.26562,123.9074 4.25,0 10.34375,19.51563 0,-19.51563 3.0625,0 0,23.32813 -4.25,0 -10.34375,-19.51563 0,19.51563 -3.0625,0 0,-23.32813"
-         id="path3328"
-         inkscape:connector-curvature="0" />
-      <path
-         d="m 432.10937,143.9074 0,-6.26562 -5.15625,0 0,-2.59375 8.28125,0 0,10.01562 c -1.21877,0.86459 -2.56251,1.52084 -4.03125,1.96875 -1.46876,0.4375 -3.03647,0.65625 -4.70312,0.65625 -3.64584,0 -6.50001,-1.0625 -8.5625,-3.1875 -2.05209,-2.13541 -3.07813,-5.10416 -3.07813,-8.90625 0,-3.81248 1.02604,-6.78123 3.07813,-8.90625 2.06249,-2.13539 4.91666,-3.2031 8.5625,-3.20312 1.52082,2e-5 2.96353,0.18752 4.32812,0.5625 1.37499,0.37502 2.64061,0.9271 3.79688,1.65625 l 0,3.35937 c -1.16669,-0.98956 -2.40627,-1.73435 -3.71875,-2.23437 -1.31252,-0.49998 -2.69272,-0.74998 -4.14063,-0.75 -2.85417,2e-5 -5,0.79689 -6.4375,2.39062 -1.42708,1.59377 -2.14063,3.96877 -2.14062,7.125 -10e-6,3.14585 0.71354,5.51563 2.14062,7.10938 1.4375,1.59375 3.58333,2.39063 6.4375,2.39062 1.11457,1e-5 2.10936,-0.0937 2.98438,-0.28125 0.87498,-0.19791 1.66144,-0.49999 2.35937,-0.90625"
-         id="path3330"
-         inkscape:connector-curvature="0" />
-      <path
-         d="m 459.9375,122.92303 0,2.39062 -2.75,0 c -1.03126,3e-5 -1.75001,0.20836 -2.15625,0.625 -0.39584,0.41669 -0.59376,1.16669 -0.59375,2.25 l 0,1.54688 4.73437,0 0,2.23437 -4.73437,0 0,15.26563 -2.89063,0 0,-15.26563 -2.75,0 0,-2.23437 2.75,0 0,-1.21875 c 0,-1.9479 0.45313,-3.36456 1.35938,-4.25 0.90624,-0.89581 2.34374,-1.34373 4.3125,-1.34375 l 2.71875,0"
-         id="path3332"
-         inkscape:connector-curvature="0" />
-      <path
-         d="m 469.10937,131.75115 c -1.54167,2e-5 -2.76042,0.60419 -3.65625,1.8125 -0.89583,1.19793 -1.34375,2.84376 -1.34375,4.9375 0,2.09376 0.44271,3.7448 1.32813,4.95313 0.89583,1.19792 2.11978,1.79688 3.67187,1.79687 1.53124,1e-5 2.74478,-0.60416 3.64063,-1.8125 0.89582,-1.20832 1.34374,-2.85416 1.34375,-4.9375 -10e-6,-2.0729 -0.44793,-3.71353 -1.34375,-4.92187 -0.89585,-1.21874 -2.10939,-1.82811 -3.64063,-1.82813 m 0,-2.4375 c 2.49999,2e-5 4.46353,0.81252 5.89063,2.4375 1.42707,1.62502 2.14061,3.87502 2.14062,6.75 -1e-5,2.86459 -0.71355,5.11459 -2.14062,6.75 -1.4271,1.625 -3.39064,2.4375 -5.89063,2.4375 -2.51042,0 -4.47917,-0.8125 -5.90625,-2.4375 -1.41666,-1.63541 -2.125,-3.88541 -2.125,-6.75 0,-2.87498 0.70834,-5.12498 2.125,-6.75 1.42708,-1.62498 3.39583,-2.43748 5.90625,-2.4375"
-         id="path3334"
-         inkscape:connector-curvature="0" />
-      <path
-         d="m 492.03125,132.42303 c -0.32293,-0.18749 -0.6771,-0.3229 -1.0625,-0.40625 -0.37501,-0.0937 -0.79168,-0.14061 -1.25,-0.14063 -1.62501,2e-5 -2.87501,0.53127 -3.75,1.59375 -0.86459,1.0521 -1.29688,2.56772 -1.29688,4.54688 l 0,9.21875 -2.89062,0 0,-17.5 2.89062,0 0,2.71875 c 0.60417,-1.06249 1.39062,-1.84894 2.35938,-2.35938 0.96874,-0.52081 2.14582,-0.78123 3.53125,-0.78125 0.1979,2e-5 0.41665,0.0156 0.65625,0.0469 0.23957,0.0208 0.5052,0.0573 0.79687,0.10937 l 0.0156,2.95313"
-         id="path3336"
-         inkscape:connector-curvature="0" />
-      <path
-         d="m 516.78125,138.2824 c -10e-6,-2.08332 -0.43231,-3.6979 -1.29688,-4.84375 -0.85417,-1.14581 -2.0573,-1.71873 -3.60937,-1.71875 -1.54167,2e-5 -2.7448,0.57294 -3.60938,1.71875 -0.85417,1.14585 -1.28125,2.76043 -1.28125,4.84375 0,2.07293 0.42708,3.6823 1.28125,4.82813 0.86458,1.14583 2.06771,1.71875 3.60938,1.71875 1.55207,0 2.7552,-0.57292 3.60937,-1.71875 0.86457,-1.14583 1.29687,-2.7552 1.29688,-4.82813 m 2.875,6.78125 c -2e-5,2.97917 -0.66148,5.19271 -1.98438,6.64063 -1.32293,1.45833 -3.34897,2.18749 -6.07812,2.1875 -1.01043,-1e-5 -1.96355,-0.0781 -2.85938,-0.23438 -0.89583,-0.14584 -1.76562,-0.375 -2.60937,-0.6875 l 0,-2.79687 c 0.84375,0.45833 1.67708,0.79687 2.5,1.01562 0.82291,0.21875 1.66145,0.32812 2.51562,0.32813 1.88541,-1e-5 3.29687,-0.4948 4.23438,-1.48438 0.93749,-0.97916 1.40624,-2.46354 1.40625,-4.45312 l 0,-1.42188 c -0.59376,1.03126 -1.35418,1.80209 -2.28125,2.3125 -0.92709,0.51042 -2.03647,0.76563 -3.32813,0.76563 -2.14584,0 -3.875,-0.81771 -5.1875,-2.45313 -1.3125,-1.63541 -1.96875,-3.80207 -1.96875,-6.5 0,-2.70832 0.65625,-4.88019 1.96875,-6.51562 1.3125,-1.6354 3.04166,-2.45311 5.1875,-2.45313 1.29166,2e-5 2.40104,0.25523 3.32813,0.76563 0.92707,0.51043 1.68749,1.28126 2.28125,2.3125 l 0,-2.65625 2.875,0 0,15.32812"
-         id="path3338"
-         inkscape:connector-curvature="0" />
-      <path
-         d="m 532.35937,131.75115 c -1.54167,2e-5 -2.76042,0.60419 -3.65625,1.8125 -0.89583,1.19793 -1.34375,2.84376 -1.34375,4.9375 0,2.09376 0.44271,3.7448 1.32813,4.95313 0.89583,1.19792 2.11978,1.79688 3.67187,1.79687 1.53124,1e-5 2.74478,-0.60416 3.64063,-1.8125 0.89582,-1.20832 1.34374,-2.85416 1.34375,-4.9375 -10e-6,-2.0729 -0.44793,-3.71353 -1.34375,-4.92187 -0.89585,-1.21874 -2.10939,-1.82811 -3.64063,-1.82813 m 0,-2.4375 c 2.49999,2e-5 4.46353,0.81252 5.89063,2.4375 1.42707,1.62502 2.14061,3.87502 2.14062,6.75 -10e-6,2.86459 -0.71355,5.11459 -2.14062,6.75 -1.4271,1.625 -3.39064,2.4375 -5.89063,2.4375 -2.51042,0 -4.47917,-0.8125 -5.90625,-2.4375 -1.41666,-1.63541 -2.125,-3.88541 -2.125,-6.75 0,-2.87498 0.70834,-5.12498 2.125,-6.75 1.42708,-1.62498 3.39583,-2.43748 5.90625,-2.4375"
-         id="path3340"
-         inkscape:connector-curvature="0" />
-      <path
-         d="m 556.65625,132.39178 0,-9.46875 2.875,0 0,24.3125 -2.875,0 0,-2.625 c -0.60418,1.04167 -1.3698,1.81771 -2.29688,2.32812 -0.91667,0.5 -2.02084,0.75 -3.3125,0.75 -2.11459,0 -3.83854,-0.84375 -5.17187,-2.53125 -1.32292,-1.68749 -1.98438,-3.90624 -1.98438,-6.65625 0,-2.74998 0.66146,-4.96873 1.98438,-6.65625 1.33333,-1.68748 3.05728,-2.53123 5.17187,-2.53125 1.29166,2e-5 2.39583,0.25523 3.3125,0.76563 0.92708,0.50002 1.6927,1.27085 2.29688,2.3125 m -9.79688,6.10937 c 0,2.11459 0.43229,3.77605 1.29688,4.98438 0.87499,1.19792 2.07291,1.79688 3.59375,1.79687 1.52082,1e-5 2.71874,-0.59895 3.59375,-1.79687 0.87499,-1.20833 1.31249,-2.86979 1.3125,-4.98438 -10e-6,-2.11457 -0.43751,-3.77082 -1.3125,-4.96875 -0.87501,-1.20831 -2.07293,-1.81248 -3.59375,-1.8125 -1.52084,2e-5 -2.71876,0.60419 -3.59375,1.8125 -0.86459,1.19793 -1.29688,2.85418 -1.29688,4.96875"
-         id="path3342"
-         inkscape:connector-curvature="0" />
-      <path
-         d="m 586.79687,130.25115 0,2.71875 c -0.81251,-0.41665 -1.65626,-0.72915 -2.53125,-0.9375 -0.87501,-0.20831 -1.78125,-0.31248 -2.71875,-0.3125 -1.42709,2e-5 -2.5,0.21877 -3.21875,0.65625 -0.70833,0.43752 -1.0625,1.09377 -1.0625,1.96875 0,0.66668 0.25521,1.19272 0.76563,1.57813 0.51041,0.37501 1.53645,0.73438 3.07812,1.07812 l 0.98438,0.21875 c 2.04166,0.43751 3.48957,1.0573 4.34375,1.85938 0.86457,0.79167 1.29686,1.90105 1.29687,3.32812 -10e-6,1.62501 -0.64584,2.91146 -1.9375,3.85938 -1.28126,0.94792 -3.04688,1.42187 -5.29687,1.42187 -0.93751,0 -1.91667,-0.0937 -2.9375,-0.28125 -1.01042,-0.17708 -2.07813,-0.44791 -3.20313,-0.8125 l 0,-2.96875 c 1.0625,0.55209 2.10938,0.96876 3.14063,1.25 1.03124,0.27084 2.05208,0.40626 3.0625,0.40625 1.35416,1e-5 2.39582,-0.22916 3.125,-0.6875 0.72915,-0.46874 1.09374,-1.12499 1.09375,-1.96875 -10e-6,-0.78124 -0.26564,-1.3802 -0.79688,-1.79687 -0.52084,-0.41666 -1.67188,-0.8177 -3.45312,-1.20313 l -1,-0.23437 c -1.78126,-0.37499 -3.06771,-0.94791 -3.85938,-1.71875 -0.79166,-0.78124 -1.1875,-1.84895 -1.1875,-3.20313 0,-1.64582 0.58334,-2.91665 1.75,-3.8125 1.16667,-0.89581 2.82292,-1.34373 4.96875,-1.34375 1.0625,2e-5 2.06249,0.0781 3,0.23438 0.93749,0.15627 1.80207,0.39064 2.59375,0.70312"
-         id="path3344"
-         inkscape:connector-curvature="0" />
-      <path
-         d="m 600.28125,138.43865 c -2.32293,1e-5 -3.9323,0.26564 -4.82813,0.79688 -0.89583,0.53126 -1.34375,1.43751 -1.34375,2.71875 0,1.02084 0.33333,1.83334 1,2.4375 0.67708,0.59375 1.59375,0.89063 2.75,0.89062 1.59374,1e-5 2.86979,-0.56249 3.82813,-1.6875 0.96874,-1.13541 1.45311,-2.64062 1.45312,-4.51562 l 0,-0.64063 -2.85937,0 m 5.73437,-1.1875 0,9.98438 -2.875,0 0,-2.65625 c -0.65626,1.0625 -1.47397,1.84896 -2.45312,2.35937 -0.97918,0.5 -2.17709,0.75 -3.59375,0.75 -1.79167,0 -3.21875,-0.5 -4.28125,-1.5 -1.05209,-1.01041 -1.57813,-2.35937 -1.57813,-4.04687 0,-1.96874 0.65625,-3.45312 1.96875,-4.45313 1.32292,-0.99999 3.29166,-1.49999 5.90625,-1.5 l 4.03125,0 0,-0.28125 c -10e-6,-1.3229 -0.43751,-2.34373 -1.3125,-3.0625 -0.86459,-0.72915 -2.08334,-1.09373 -3.65625,-1.09375 -1,2e-5 -1.97396,0.11981 -2.92187,0.35938 -0.94792,0.2396 -1.85938,0.59897 -2.73438,1.07812 l 0,-2.65625 c 1.05208,-0.40623 2.07292,-0.70831 3.0625,-0.90625 0.98958,-0.20831 1.95312,-0.31248 2.89063,-0.3125 2.53124,2e-5 4.42186,0.65627 5.67187,1.96875 1.24999,1.31252 1.87499,3.3021 1.875,5.96875"
-         id="path3346"
-         inkscape:connector-curvature="0" />
-      <path
-         d="m 611.84375,122.92303 2.89062,0 0,14.35937 8.57813,-7.54687 3.67187,0 -9.28125,8.1875 9.67188,9.3125 -3.75,0 -8.89063,-8.54688 0,8.54688 -2.89062,0 0,-24.3125"
-         id="path3348"
-         inkscape:connector-curvature="0" />
-      <path
-         d="m 644.35937,137.76678 0,1.40625 -13.21875,0 c 0.125,1.97917 0.71875,3.48959 1.78125,4.53125 1.07291,1.03125 2.5625,1.54688 4.46875,1.54687 1.10416,1e-5 2.17187,-0.13541 3.20313,-0.40625 1.04165,-0.27083 2.0729,-0.67708 3.09375,-1.21875 l 0,2.71875 c -1.03127,0.4375 -2.08856,0.77084 -3.17188,1 -1.08334,0.22917 -2.1823,0.34375 -3.29687,0.34375 -2.79167,0 -5.00521,-0.8125 -6.64063,-2.4375 -1.625,-1.62499 -2.4375,-3.82291 -2.4375,-6.59375 0,-2.86457 0.77084,-5.1354 2.3125,-6.8125 1.55208,-1.68748 3.64062,-2.53123 6.26563,-2.53125 2.35415,2e-5 4.21353,0.76044 5.57812,2.28125 1.37499,1.51043 2.06249,3.56772 2.0625,6.17188 m -2.875,-0.84375 c -0.0208,-1.57291 -0.46355,-2.82811 -1.32812,-3.76563 -0.85418,-0.93748 -1.9896,-1.40623 -3.40625,-1.40625 -1.60418,2e-5 -2.89063,0.45314 -3.85938,1.35938 -0.95833,0.90626 -1.51042,2.1823 -1.65625,3.82812 l 10.25,-0.0156"
-         id="path3350"
-         inkscape:connector-curvature="0" />
-      <path
-         d="m 649.8125,143.26678 3.29687,0 0,2.6875 -2.5625,5 -2.01562,0 1.28125,-5 0,-2.6875"
-         id="path3352"
-         inkscape:connector-curvature="0" />
-      <path
-         d="m 676.73437,148.86053 c -0.8125,2.08333 -1.60417,3.4427 -2.375,4.07812 -0.77084,0.63541 -1.80208,0.95312 -3.09375,0.95313 l -2.29687,0 0,-2.40625 1.6875,0 c 0.79166,-1e-5 1.40624,-0.18751 1.84375,-0.5625 0.43749,-0.375 0.92187,-1.26042 1.45312,-2.65625 l 0.51563,-1.3125 -7.07813,-17.21875 3.04688,0 5.46875,13.6875 5.46875,-13.6875 3.04687,0 -7.6875,19.125"
-         id="path3354"
-         inkscape:connector-curvature="0" />
-      <path
-         d="m 695.17187,131.75115 c -1.54167,2e-5 -2.76042,0.60419 -3.65625,1.8125 -0.89583,1.19793 -1.34375,2.84376 -1.34375,4.9375 0,2.09376 0.44271,3.7448 1.32813,4.95313 0.89583,1.19792 2.11978,1.79688 3.67187,1.79687 1.53124,1e-5 2.74478,-0.60416 3.64063,-1.8125 0.89582,-1.20832 1.34374,-2.85416 1.34375,-4.9375 -10e-6,-2.0729 -0.44793,-3.71353 -1.34375,-4.92187 -0.89585,-1.21874 -2.10939,-1.82811 -3.64063,-1.82813 m 0,-2.4375 c 2.49999,2e-5 4.46353,0.81252 5.89063,2.4375 1.42707,1.62502 2.14061,3.87502 2.14062,6.75 -10e-6,2.86459 -0.71355,5.11459 -2.14062,6.75 -1.4271,1.625 -3.39064,2.4375 -5.89063,2.4375 -2.51042,0 -4.47917,-0.8125 -5.90625,-2.4375 -1.41666,-1.63541 -2.125,-3.88541 -2.125,-6.75 0,-2.87498 0.70834,-5.12498 2.125,-6.75 1.42708,-1.62498 3.39583,-2.43748 5.90625,-2.4375"
-         id="path3356"
-         inkscape:connector-curvature="0" />
-      <path
-         d="m 707.65625,140.32928 0,-10.59375 2.875,0 0,10.48437 c -10e-6,1.65626 0.32291,2.90105 0.96875,3.73438 0.64583,0.82292 1.61458,1.23438 2.90625,1.23437 1.55207,1e-5 2.77603,-0.49479 3.67187,-1.48437 0.90624,-0.98958 1.35937,-2.33854 1.35938,-4.04688 l 0,-9.92187 2.875,0 0,17.5 -2.875,0 0,-2.6875 c -0.69793,1.0625 -1.51043,1.85417 -2.4375,2.375 -0.91668,0.51041 -1.98439,0.76562 -3.20313,0.76562 -2.01042,0 -3.53646,-0.625 -4.57812,-1.875 -1.04167,-1.24999 -1.5625,-3.07812 -1.5625,-5.48437 m 7.23437,-11.01563 0,0"
-         id="path3358"
-         inkscape:connector-curvature="0" />
-      <path
-         d="m 148.90625,164.42303 c -0.32293,-0.18749 -0.6771,-0.3229 -1.0625,-0.40625 -0.37501,-0.0937 -0.79168,-0.14061 -1.25,-0.14063 -1.62501,2e-5 -2.87501,0.53127 -3.75,1.59375 -0.86459,1.0521 -1.29688,2.56772 -1.29688,4.54688 l 0,9.21875 -2.89062,0 0,-17.5 2.89062,0 0,2.71875 c 0.60417,-1.06249 1.39062,-1.84894 2.35938,-2.35938 0.96874,-0.52081 2.14582,-0.78123 3.53125,-0.78125 0.1979,2e-5 0.41665,0.0156 0.65625,0.0469 0.23957,0.0208 0.5052,0.0573 0.79687,0.10937 l 0.0156,2.95313"
-         id="path3360"
-         inkscape:connector-curvature="0" />
-      <path
-         d="m 166.23437,169.76678 0,1.40625 -13.21875,0 c 0.125,1.97917 0.71875,3.48959 1.78125,4.53125 1.07291,1.03125 2.5625,1.54688 4.46875,1.54687 1.10416,1e-5 2.17187,-0.13541 3.20313,-0.40625 1.04165,-0.27083 2.0729,-0.67708 3.09375,-1.21875 l 0,2.71875 c -1.03127,0.4375 -2.08856,0.77084 -3.17188,1 -1.08334,0.22917 -2.1823,0.34375 -3.29687,0.34375 -2.79167,0 -5.00521,-0.8125 -6.64063,-2.4375 -1.625,-1.62499 -2.4375,-3.82291 -2.4375,-6.59375 0,-2.86457 0.77084,-5.1354 2.3125,-6.8125 1.55208,-1.68748 3.64062,-2.53123 6.26563,-2.53125 2.35415,2e-5 4.21353,0.76044 5.57812,2.28125 1.37499,1.51043 2.06249,3.56772 2.0625,6.17188 m -2.875,-0.84375 c -0.0208,-1.57291 -0.46355,-2.82811 -1.32812,-3.76563 -0.85418,-0.93748 -1.9896,-1.40623 -3.40625,-1.40625 -1.60418,2e-5 -2.89063,0.45314 -3.85938,1.35938 -0.95833,0.90626 -1.51042,2.1823 -1.65625,3.82812 l 10.25,-0.0156"
-         id="path3362"
-         inkscape:connector-curvature="0" />
-      <path
-         d="m 178.90625,170.43865 c -2.32293,1e-5 -3.9323,0.26564 -4.82813,0.79688 -0.89583,0.53126 -1.34375,1.43751 -1.34375,2.71875 0,1.02084 0.33333,1.83334 1,2.4375 0.67708,0.59375 1.59375,0.89063 2.75,0.89062 1.59374,1e-5 2.86979,-0.56249 3.82813,-1.6875 0.96874,-1.13541 1.45311,-2.64062 1.45312,-4.51562 l 0,-0.64063 -2.85937,0 m 5.73437,-1.1875 0,9.98438 -2.875,0 0,-2.65625 c -0.65626,1.0625 -1.47397,1.84896 -2.45312,2.35937 -0.97918,0.5 -2.17709,0.75 -3.59375,0.75 -1.79167,0 -3.21875,-0.5 -4.28125,-1.5 -1.05209,-1.01041 -1.57813,-2.35937 -1.57813,-4.04687 0,-1.96874 0.65625,-3.45312 1.96875,-4.45313 1.32292,-0.99999 3.29166,-1.49999 5.90625,-1.5 l 4.03125,0 0,-0.28125 c -1e-5,-1.3229 -0.43751,-2.34373 -1.3125,-3.0625 -0.86459,-0.72915 -2.08334,-1.09373 -3.65625,-1.09375 -1,2e-5 -1.97396,0.11981 -2.92187,0.35938 -0.94792,0.2396 -1.85938,0.59897 -2.73438,1.07812 l 0,-2.65625 c 1.05208,-0.40623 2.07292,-0.70831 3.0625,-0.90625 0.98958,-0.20831 1.95312,-0.31248 2.89063,-0.3125 2.53124,2e-5 4.42186,0.65627 5.67187,1.96875 1.24999,1.31252 1.87499,3.3021 1.875,5.96875"
-         id="path3364"
-         inkscape:connector-curvature="0" />
-      <path
-         d="m 190.57812,154.92303 2.875,0 0,24.3125 -2.875,0 0,-24.3125"
-         id="path3366"
-         inkscape:connector-curvature="0" />
-      <path
-         d="m 199.45312,154.92303 2.875,0 0,24.3125 -2.875,0 0,-24.3125"
-         id="path3368"
-         inkscape:connector-curvature="0" />
-      <path
-         d="m 215.60937,180.86053 c -0.8125,2.08333 -1.60417,3.4427 -2.375,4.07812 -0.77084,0.63541 -1.80208,0.95312 -3.09375,0.95313 l -2.29687,0 0,-2.40625 1.6875,0 c 0.79166,-1e-5 1.40624,-0.18751 1.84375,-0.5625 0.43749,-0.375 0.92187,-1.26042 1.45312,-2.65625 l 0.51563,-1.3125 -7.07813,-17.21875 3.04688,0 5.46875,13.6875 5.46875,-13.6875 3.04687,0 -7.6875,19.125"
-         id="path3370"
-         inkscape:connector-curvature="0" />
-      <path
-         d="m 252,168.67303 0,10.5625 -2.875,0 0,-10.46875 c -1e-5,-1.65624 -0.32293,-2.89582 -0.96875,-3.71875 -0.64585,-0.8229 -1.6146,-1.23436 -2.90625,-1.23438 -1.55209,2e-5 -2.77605,0.49481 -3.67188,1.48438 -0.89583,0.98959 -1.34375,2.33855 -1.34375,4.04687 l 0,9.89063 -2.89062,0 0,-17.5 2.89062,0 0,2.71875 c 0.6875,-1.05207 1.49479,-1.83853 2.42188,-2.35938 0.93749,-0.52081 2.01561,-0.78123 3.23437,-0.78125 2.01041,2e-5 3.53124,0.62502 4.5625,1.875 1.03124,1.2396 1.54686,3.06772 1.54688,5.48438"
-         id="path3372"
-         inkscape:connector-curvature="0" />
-      <path
-         d="m 272.73437,169.76678 0,1.40625 -13.21875,0 c 0.125,1.97917 0.71875,3.48959 1.78125,4.53125 1.07291,1.03125 2.5625,1.54688 4.46875,1.54687 1.10416,1e-5 2.17187,-0.13541 3.20313,-0.40625 1.04165,-0.27083 2.0729,-0.67708 3.09375,-1.21875 l 0,2.71875 c -1.03127,0.4375 -2.08856,0.77084 -3.17188,1 -1.08334,0.22917 -2.1823,0.34375 -3.29687,0.34375 -2.79167,0 -5.00521,-0.8125 -6.64063,-2.4375 -1.625,-1.62499 -2.4375,-3.82291 -2.4375,-6.59375 0,-2.86457 0.77084,-5.1354 2.3125,-6.8125 1.55208,-1.68748 3.64062,-2.53123 6.26563,-2.53125 2.35415,2e-5 4.21353,0.76044 5.57812,2.28125 1.37499,1.51043 2.06249,3.56772 2.0625,6.17188 m -2.875,-0.84375 c -0.0208,-1.57291 -0.46355,-2.82811 -1.32812,-3.76563 -0.85418,-0.93748 -1.9896,-1.40623 -3.40625,-1.40625 -1.60418,2e-5 -2.89063,0.45314 -3.85938,1.35938 -0.95833,0.90626 -1.51042,2.1823 -1.65625,3.82812 l 10.25,-0.0156"
-         id="path3374"
-         inkscape:connector-curvature="0" />
-      <path
-         d="m 292.42187,169.76678 0,1.40625 -13.21875,0 c 0.125,1.97917 0.71875,3.48959 1.78125,4.53125 1.07291,1.03125 2.5625,1.54688 4.46875,1.54687 1.10416,1e-5 2.17187,-0.13541 3.20313,-0.40625 1.04165,-0.27083 2.0729,-0.67708 3.09375,-1.21875 l 0,2.71875 c -1.03127,0.4375 -2.08856,0.77084 -3.17188,1 -1.08334,0.22917 -2.1823,0.34375 -3.29687,0.34375 -2.79167,0 -5.00521,-0.8125 -6.64063,-2.4375 -1.625,-1.62499 -2.4375,-3.82291 -2.4375,-6.59375 0,-2.86457 0.77084,-5.1354 2.3125,-6.8125 1.55208,-1.68748 3.64062,-2.53123 6.26563,-2.53125 2.35415,2e-5 4.21353,0.76044 5.57812,2.28125 1.37499,1.51043 2.06249,3.56772 2.0625,6.17188 m -2.875,-0.84375 c -0.0208,-1.57291 -0.46355,-2.82811 -1.32812,-3.76563 -0.85418,-0.93748 -1.9896,-1.40623 -3.40625,-1.40625 -1.60418,2e-5 -2.89063,0.45314 -3.85938,1.35938 -0.95833,0.90626 -1.51042,2.1823 -1.65625,3.82812 l 10.25,-0.0156"
-         id="path3376"
-         inkscape:connector-curvature="0" />
-      <path
-         d="m 308.65625,164.39178 0,-9.46875 2.875,0 0,24.3125 -2.875,0 0,-2.625 c -0.60418,1.04167 -1.3698,1.81771 -2.29688,2.32812 -0.91667,0.5 -2.02084,0.75 -3.3125,0.75 -2.11459,0 -3.83854,-0.84375 -5.17187,-2.53125 -1.32292,-1.68749 -1.98438,-3.90624 -1.98438,-6.65625 0,-2.74998 0.66146,-4.96873 1.98438,-6.65625 1.33333,-1.68748 3.05728,-2.53123 5.17187,-2.53125 1.29166,2e-5 2.39583,0.25523 3.3125,0.76563 0.92708,0.50002 1.6927,1.27085 2.29688,2.3125 m -9.79688,6.10937 c 0,2.11459 0.43229,3.77605 1.29688,4.98438 0.87499,1.19792 2.07291,1.79688 3.59375,1.79687 1.52082,1e-5 2.71874,-0.59895 3.59375,-1.79687 0.87499,-1.20833 1.31249,-2.86979 1.3125,-4.98438 -10e-6,-2.11457 -0.43751,-3.77082 -1.3125,-4.96875 -0.87501,-1.20831 -2.07293,-1.81248 -3.59375,-1.8125 -1.52084,2e-5 -2.71876,0.60419 -3.59375,1.8125 -0.86459,1.19793 -1.29688,2.85418 -1.29688,4.96875"
-         id="path3378"
-         inkscape:connector-curvature="0" />
-      <path
-         d="m 330.48437,156.76678 0,4.96875 5.92188,0 0,2.23437 -5.92188,0 0,9.5 c 0,1.42709 0.19271,2.34376 0.57813,2.75 0.39583,0.40626 1.1927,0.60938 2.39062,0.60938 l 2.95313,0 0,2.40625 -2.95313,0 c -2.21875,0 -3.75,-0.41146 -4.59375,-1.23438 -0.84375,-0.83333 -1.26562,-2.34374 -1.26562,-4.53125 l 0,-9.5 -2.10938,0 0,-2.23437 2.10938,0 0,-4.96875 2.89062,0"
-         id="path3380"
-         inkscape:connector-curvature="0" />
-      <path
-         d="m 346.98437,163.75115 c -1.54167,2e-5 -2.76042,0.60419 -3.65625,1.8125 -0.89583,1.19793 -1.34375,2.84376 -1.34375,4.9375 0,2.09376 0.44271,3.7448 1.32813,4.95313 0.89583,1.19792 2.11978,1.79688 3.67187,1.79687 1.53124,1e-5 2.74478,-0.60416 3.64063,-1.8125 0.89582,-1.20832 1.34374,-2.85416 1.34375,-4.9375 -10e-6,-2.0729 -0.44793,-3.71353 -1.34375,-4.92187 -0.89585,-1.21874 -2.10939,-1.82811 -3.64063,-1.82813 m 0,-2.4375 c 2.49999,2e-5 4.46353,0.81252 5.89063,2.4375 1.42707,1.62502 2.14061,3.87502 2.14062,6.75 -1e-5,2.86459 -0.71355,5.11459 -2.14062,6.75 -1.4271,1.625 -3.39064,2.4375 -5.89063,2.4375 -2.51042,0 -4.47917,-0.8125 -5.90625,-2.4375 -1.41666,-1.63541 -2.125,-3.88541 -2.125,-6.75 0,-2.87498 0.70834,-5.12498 2.125,-6.75 1.42708,-1.62498 3.39583,-2.43748 5.90625,-2.4375"
-         id="path3382"
-         inkscape:connector-curvature="0" />
-      <path
-         d="m 372.73437,176.61053 0,9.28125 -2.89062,0 0,-24.15625 2.89062,0 0,2.65625 c 0.60417,-1.04165 1.36458,-1.81248 2.28125,-2.3125 0.92708,-0.5104 2.03124,-0.76561 3.3125,-0.76563 2.12499,2e-5 3.84895,0.84377 5.17188,2.53125 1.33332,1.68752 1.99998,3.90627 2,6.65625 -2e-5,2.75001 -0.66668,4.96876 -2,6.65625 -1.32293,1.6875 -3.04689,2.53125 -5.17188,2.53125 -1.28126,0 -2.38542,-0.25 -3.3125,-0.75 -0.91667,-0.51041 -1.67708,-1.28645 -2.28125,-2.32812 m 9.78125,-6.10938 c -1e-5,-2.11457 -0.43751,-3.77082 -1.3125,-4.96875 -0.86459,-1.20831 -2.0573,-1.81248 -3.57812,-1.8125 -1.52084,2e-5 -2.71876,0.60419 -3.59375,1.8125 -0.86459,1.19793 -1.29688,2.85418 -1.29688,4.96875 0,2.11459 0.43229,3.77605 1.29688,4.98438 0.87499,1.19792 2.07291,1.79688 3.59375,1.79687 1.52082,1e-5 2.71353,-0.59895 3.57812,-1.79687 0.87499,-1.20833 1.31249,-2.86979 1.3125,-4.98438"
-         id="path3384"
-         inkscape:connector-curvature="0" />
-      <path
-         d="m 390.26562,154.92303 2.875,0 0,24.3125 -2.875,0 0,-24.3125"
-         id="path3386"
-         inkscape:connector-curvature="0" />
-      <path
-         d="m 414.10937,169.76678 0,1.40625 -13.21875,0 c 0.125,1.97917 0.71875,3.48959 1.78125,4.53125 1.07291,1.03125 2.5625,1.54688 4.46875,1.54687 1.10416,1e-5 2.17187,-0.13541 3.20313,-0.40625 1.04165,-0.27083 2.0729,-0.67708 3.09375,-1.21875 l 0,2.71875 c -1.03127,0.4375 -2.08856,0.77084 -3.17188,1 -1.08334,0.22917 -2.1823,0.34375 -3.29687,0.34375 -2.79167,0 -5.00521,-0.8125 -6.64063,-2.4375 -1.625,-1.62499 -2.4375,-3.82291 -2.4375,-6.59375 0,-2.86457 0.77084,-5.1354 2.3125,-6.8125 1.55208,-1.68748 3.64062,-2.53123 6.26563,-2.53125 2.35415,2e-5 4.21353,0.76044 5.57812,2.28125 1.37499,1.51043 2.06249,3.56772 2.0625,6.17188 m -2.875,-0.84375 c -0.0208,-1.57291 -0.46355,-2.82811 -1.32812,-3.76563 -0.85418,-0.93748 -1.9896,-1.40623 -3.40625,-1.40625 -1.60418,2e-5 -2.89063,0.45314 -3.85938,1.35938 -0.95833,0.90626 -1.51042,2.1823 -1.65625,3.82812 l 10.25,-0.0156"
-         id="path3388"
-         inkscape:connector-curvature="0" />
-      <path
-         d="m 426.78125,170.43865 c -2.32293,1e-5 -3.9323,0.26564 -4.82813,0.79688 -0.89583,0.53126 -1.34375,1.43751 -1.34375,2.71875 0,1.02084 0.33333,1.83334 1,2.4375 0.67708,0.59375 1.59375,0.89063 2.75,0.89062 1.59374,1e-5 2.86979,-0.56249 3.82813,-1.6875 0.96874,-1.13541 1.45311,-2.64062 1.45312,-4.51562 l 0,-0.64063 -2.85937,0 m 5.73437,-1.1875 0,9.98438 -2.875,0 0,-2.65625 c -0.65626,1.0625 -1.47397,1.84896 -2.45312,2.35937 -0.97918,0.5 -2.17709,0.75 -3.59375,0.75 -1.79167,0 -3.21875,-0.5 -4.28125,-1.5 -1.05209,-1.01041 -1.57813,-2.35937 -1.57813,-4.04687 0,-1.96874 0.65625,-3.45312 1.96875,-4.45313 1.32292,-0.99999 3.29166,-1.49999 5.90625,-1.5 l 4.03125,0 0,-0.28125 c -1e-5,-1.3229 -0.43751,-2.34373 -1.3125,-3.0625 -0.86459,-0.72915 -2.08334,-1.09373 -3.65625,-1.09375 -1,2e-5 -1.97396,0.11981 -2.92187,0.35938 -0.94792,0.2396 -1.85938,0.59897 -2.73438,1.07812 l 0,-2.65625 c 1.05208,-0.40623 2.07292,-0.70831 3.0625,-0.90625 0.98958,-0.20831 1.95312,-0.31248 2.89063,-0.3125 2.53124,2e-5 4.42186,0.65627 5.67187,1.96875 1.24999,1.31252 1.87499,3.3021 1.875,5.96875"
-         id="path3390"
-         inkscape:connector-curvature="0" />
-      <path
-         d="m 449.60937,162.25115 0,2.71875 c -0.81251,-0.41665 -1.65626,-0.72915 -2.53125,-0.9375 -0.87501,-0.20831 -1.78125,-0.31248 -2.71875,-0.3125 -1.42709,2e-5 -2.5,0.21877 -3.21875,0.65625 -0.70833,0.43752 -1.0625,1.09377 -1.0625,1.96875 0,0.66668 0.25521,1.19272 0.76563,1.57813 0.51041,0.37501 1.53645,0.73438 3.07812,1.07812 l 0.98438,0.21875 c 2.04166,0.43751 3.48957,1.0573 4.34375,1.85938 0.86457,0.79167 1.29686,1.90105 1.29687,3.32812 -1e-5,1.62501 -0.64584,2.91146 -1.9375,3.85938 -1.28126,0.94792 -3.04688,1.42187 -5.29687,1.42187 -0.93751,0 -1.91667,-0.0937 -2.9375,-0.28125 -1.01042,-0.17708 -2.07813,-0.44791 -3.20313,-0.8125 l 0,-2.96875 c 1.0625,0.55209 2.10938,0.96876 3.14063,1.25 1.03124,0.27084 2.05208,0.40626 3.0625,0.40625 1.35416,1e-5 2.39582,-0.22916 3.125,-0.6875 0.72915,-0.46874 1.09374,-1.12499 1.09375,-1.96875 -10e-6,-0.78124 -0.26564,-1.3802 -0.79688,-1.79687 -0.52084,-0.41666 -1.67188,-0.8177 -3.45312,-1.20313 l -1,-0.23437 c -1.78126,-0.37499 -3.06771,-0.94791 -3.85938,-1.71875 -0.79166,-0.78124 -1.1875,-1.84895 -1.1875,-3.20313 0,-1.64582 0.58334,-2.91665 1.75,-3.8125 1.16667,-0.89581 2.82292,-1.34373 4.96875,-1.34375 1.0625,2e-5 2.06249,0.0781 3,0.23438 0.93749,0.15627 1.80207,0.39064 2.59375,0.70312"
-         id="path3392"
-         inkscape:connector-curvature="0" />
-      <path
-         d="m 470.10937,169.76678 0,1.40625 -13.21875,0 c 0.125,1.97917 0.71875,3.48959 1.78125,4.53125 1.07291,1.03125 2.5625,1.54688 4.46875,1.54687 1.10416,1e-5 2.17187,-0.13541 3.20313,-0.40625 1.04165,-0.27083 2.0729,-0.67708 3.09375,-1.21875 l 0,2.71875 c -1.03127,0.4375 -2.08856,0.77084 -3.17188,1 -1.08334,0.22917 -2.1823,0.34375 -3.29687,0.34375 -2.79167,0 -5.00521,-0.8125 -6.64063,-2.4375 -1.625,-1.62499 -2.4375,-3.82291 -2.4375,-6.59375 0,-2.86457 0.77084,-5.1354 2.3125,-6.8125 1.55208,-1.68748 3.64062,-2.53123 6.26563,-2.53125 2.35415,2e-5 4.21353,0.76044 5.57812,2.28125 1.37499,1.51043 2.06249,3.56772 2.0625,6.17188 m -2.875,-0.84375 c -0.0208,-1.57291 -0.46355,-2.82811 -1.32812,-3.76563 -0.85418,-0.93748 -1.9896,-1.40623 -3.40625,-1.40625 -1.60418,2e-5 -2.89063,0.45314 -3.85938,1.35938 -0.95833,0.90626 -1.51042,2.1823 -1.65625,3.82812 l 10.25,-0.0156"
-         id="path3394"
-         inkscape:connector-curvature="0" />
-      <path
-         d="m 496.20312,168.29803 c 0.67707,0.22918 1.33332,0.71876 1.96875,1.46875 0.64582,0.75001 1.29165,1.78126 1.9375,3.09375 l 3.20313,6.375 -3.39063,0 -2.98437,-5.98438 c -0.77085,-1.56249 -1.52085,-2.59895 -2.25,-3.10937 -0.71876,-0.51041 -1.70314,-0.76562 -2.95313,-0.76563 l -3.4375,0 0,9.85938 -3.15625,0 0,-23.32813 7.125,0 c 2.66666,3e-5 4.65624,0.55732 5.96875,1.67188 1.31249,1.1146 1.96874,2.79689 1.96875,5.04687 -1e-5,1.46877 -0.34376,2.68752 -1.03125,3.65625 -0.67709,0.96877 -1.66668,1.64064 -2.96875,2.01563 m -7.90625,-9.79688 0,8.28125 3.96875,0 c 1.52083,2e-5 2.66666,-0.34894 3.4375,-1.04687 0.78124,-0.70832 1.17187,-1.74478 1.17188,-3.10938 -10e-6,-1.36456 -0.39064,-2.3906 -1.17188,-3.07812 -0.77084,-0.6979 -1.91667,-1.04686 -3.4375,-1.04688 l -3.96875,0"
-         id="path3396"
-         inkscape:connector-curvature="0" />
-      <path
-         d="m 501.84375,155.9074 19.73437,0 0,2.65625 -8.28125,0 0,20.67188 -3.17187,0 0,-20.67188 -8.28125,0 0,-2.65625"
-         id="path3398"
-         inkscape:connector-curvature="0" />
-      <path
-         d="m 524.64062,155.9074 13.40625,0 0,2.65625 -10.25,0 0,6.875 9.25,0 0,2.65625 -9.25,0 0,11.14063 -3.15625,0 0,-23.32813"
-         id="path3400"
-         inkscape:connector-curvature="0" />
-      <path
-         d="m 543.07812,155.9074 4.70313,0 5.95312,15.875 5.98438,-15.875 4.70312,0 0,23.32813 -3.07812,0 0,-20.48438 -6.01563,16 -3.17187,0 -6.01563,-16 0,20.48438 -3.0625,0 0,-23.32813"
-         id="path3402"
-         inkscape:connector-curvature="0" />
-      <path
-         d="m 571.3125,175.26678 3.29687,0 0,2.6875 -2.5625,5 -2.01562,0 1.28125,-5 0,-2.6875"
-         id="path3404"
-         inkscape:connector-curvature="0" />
-      <path
-         d="m 602.14062,168.29803 c 0.67707,0.22918 1.33332,0.71876 1.96875,1.46875 0.64582,0.75001 1.29165,1.78126 1.9375,3.09375 l 3.20313,6.375 -3.39063,0 -2.98437,-5.98438 c -0.77085,-1.56249 -1.52085,-2.59895 -2.25,-3.10937 -0.71876,-0.51041 -1.70314,-0.76562 -2.95313,-0.76563 l -3.4375,0 0,9.85938 -3.15625,0 0,-23.32813 7.125,0 c 2.66666,3e-5 4.65624,0.55732 5.96875,1.67188 1.31249,1.1146 1.96874,2.79689 1.96875,5.04687 -10e-6,1.46877 -0.34376,2.68752 -1.03125,3.65625 -0.67709,0.96877 -1.66668,1.64064 -2.96875,2.01563 m -7.90625,-9.79688 0,8.28125 3.96875,0 c 1.52083,2e-5 2.66666,-0.34894 3.4375,-1.04687 0.78124,-0.70832 1.17187,-1.74478 1.17188,-3.10938 -10e-6,-1.36456 -0.39064,-2.3906 -1.17188,-3.07812 -0.77084,-0.6979 -1.91667,-1.04686 -3.4375,-1.04688 l -3.96875,0"
-         id="path3406"
-         inkscape:connector-curvature="0" />
-      <path
-         d="m 607.78125,155.9074 19.73437,0 0,2.65625 -8.28125,0 0,20.67188 -3.17187,0 0,-20.67188 -8.28125,0 0,-2.65625"
-         id="path3408"
-         inkscape:connector-curvature="0" />
-      <path
-         d="m 630.57812,155.9074 13.40625,0 0,2.65625 -10.25,0 0,6.875 9.25,0 0,2.65625 -9.25,0 0,11.14063 -3.15625,0 0,-23.32813"
-         id="path3410"
-         inkscape:connector-curvature="0" />
-      <path
-         d="m 649.01562,155.9074 4.70313,0 5.95312,15.875 5.98438,-15.875 4.70312,0 0,23.32813 -3.07812,0 0,-20.48438 -6.01563,16 -3.17187,0 -6.01563,-16 0,20.48438 -3.0625,0 0,-23.32813"
-         id="path3412"
-         inkscape:connector-curvature="0" />
-      <path
-         d="m 678.32812,175.26678 3.17188,0 0,3.96875 -3.17188,0 0,-3.96875 m 0,-19.35938 3.17188,0 0,10.23438 -0.3125,5.57812 -2.53125,0 -0.32813,-5.57812 0,-10.23438"
-         id="path3414"
-         inkscape:connector-curvature="0" />
-    </g>
-    <flowRoot
-       transform="matrix(1,0,0,1.1970692,141.42376,79.93411)"
-       style="font-size:32px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-align:center;line-height:100%;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke:none;font-family:Bitstream Vera Sans;-inkscape-font-specification:Bitstream Vera Sans"
-       id="presenterbox"
-       xml:space="preserve"><flowRegion
-         id="flowRegion2830"><rect
-           style="font-size:32px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-align:center;line-height:100%;writing-mode:lr-tb;text-anchor:middle;font-family:Bitstream Vera Sans;-inkscape-font-specification:Bitstream Vera Sans"
-           y="191.71947"
-           x="68.642532"
-           height="80"
-           width="684.7511"
-           id="rect2832" /></flowRegion><flowPara
-         id="presenternames"
-         style="font-weight:normal">By: Carl &quot;Speedy&quot; Karsten</flowPara></flowRoot>    <flowRoot
-       xml:space="preserve"
-       id="flowRoot2802"
-       style="font-size:18px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-align:left;line-height:110.00000238%;writing-mode:lr-tb;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;font-family:Bitstream Vera Sans;-inkscape-font-specification:Bitstream Vera Sans"
-       transform="matrix(1.7433323,0,0,1.2699132,-129.39729,128.36202)"><flowRegion
-         id="flowRegion2804"><rect
-           id="rect2806"
-           width="127.43188"
-           height="25.721367"
-           x="81.975098"
-           y="287.85004"
-           style="font-size:18px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-align:center;line-height:110.00000238%;writing-mode:lr-tb;text-anchor:middle;font-family:Bitstream Vera Sans;-inkscape-font-specification:Bitstream Vera Sans"
-           ry="0" /></flowRegion><flowPara
-         id="flowPara2818">Produced by</flowPara></flowRoot>    <flowRoot
-       transform="matrix(1,0,0,1.1970692,151.35566,135.93605)"
-       style="font-size:32px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-align:center;line-height:100%;writing-mode:lr-tb;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;font-family:Bitstream Vera Sans;-inkscape-font-specification:Bitstream Vera Sans"
-       id="presenterbox-5"
-       xml:space="preserve"><flowRegion
-         id="flowRegion2830-9"><rect
-           style="font-size:32px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-align:center;line-height:100%;writing-mode:lr-tb;text-anchor:middle;font-family:Bitstream Vera Sans;-inkscape-font-specification:Bitstream Vera Sans"
-           y="191.71947"
-           x="68.642532"
-           height="80"
-           width="684.7511"
-           id="rect2832-4" /></flowRegion><flowPara
-         id="presentertitle"
-         style="font-weight:normal">Video MaD Man</flowPara></flowRoot>    <flowRoot
-       xml:space="preserve"
-       id="flowRoot3030"
-       style="fill:black;stroke:none;stroke-opacity:1;stroke-width:1px;stroke-linejoin:miter;stroke-linecap:butt;fill-opacity:1;font-family:Bitstream Vera Sans;font-style:normal;font-weight:normal;font-size:40px;line-height:125%;letter-spacing:0px;word-spacing:0px"><flowRegion
-         id="flowRegion3032"><rect
-           id="rect3034"
-           width="566.68152"
-           height="76.578583"
-           x="89.53804"
-           y="469.22736" /></flowRegion><flowPara
-         id="flowPara3036" /></flowRoot>    <flowRoot
-       xml:space="preserve"
-       id="flowRoot2576-7"
-       style="font-size:16px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-align:center;line-height:100%;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke:none;font-family:Bitstream Vera Sans;-inkscape-font-specification:Bitstream Vera Sans"
-       transform="matrix(1.5228736,0,0,1.8229844,-491.19491,123.84037)"
-       inkscape:label="#flowRoot2414"><flowRegion
-         id="flowRegion2416-5"><rect
-           id="rect2418-9"
-           width="684.7511"
-           height="95.016434"
-           x="68.642532"
-           y="121.71946"
-           style="font-size:32px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-align:center;line-height:100%;writing-mode:lr-tb;text-anchor:middle;fill:#ffffff;font-family:Bitstream Vera Sans;-inkscape-font-specification:Bitstream Vera Sans" /></flowRegion><flowPara
-         id="date">September 99,9999</flowPara></flowRoot>    <g
-       id="layer1-9"
-       inkscape:label="Layer 1"
-       transform="matrix(0.46051115,0,0,0.3650844,451.30094,341.33188)">
+       transform="matrix(0.43712436,0,0,0.37628735,1108.794,468.94642)"
+       id="g6241"
+       inkscape:export-filename="/home/cats/Desktop/pyohio.png"
+       inkscape:export-xdpi="71.95591"
+       inkscape:export-ydpi="71.95591">
       <g
-         transform="translate(1220.6931,-708.49755)"
-         id="g6306">
+         id="text3233"
+         style="font-size:151.50627136px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:url(#linearGradient4039);fill-opacity:1;stroke:none;font-family:Arial;-inkscape-font-specification:Arial"
+         transform="matrix(1.2311103,0,0,1.4753166,-617.37357,-261.99886)">
         <path
            inkscape:connector-curvature="0"
-           id="rect4739"
-           d="m -2200.3023,1206.3397 1736.41842,0 0,210.3186 -1736.41842,0 z"
-           style="fill:#000000;fill-rule:evenodd;stroke:#000000;stroke-width:0.78163189px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+           id="path6805"
+           style="fill:url(#linearGradient4025);font-family:Arial;-inkscape-font-specification:Arial"
+           d="m -1248.726,1072.8942 0,-108.4513 14.7216,0 56.9628,85.1483 0,-85.1483 13.7598,0 0,108.4513 -14.7215,0 -56.9628,-85.22231 0,85.22231 -13.7599,0" />
+        <path
+           inkscape:connector-curvature="0"
+           id="path6807"
+           style="fill:url(#linearGradient4027);font-family:Arial;-inkscape-font-specification:Arial"
+           d="m -1138.8691,1072.8942 0,-108.4513 78.4163,0 0,12.79814 -64.0646,0 0,33.21596 59.9958,0 0,12.7242 -59.9958,0 0,36.9148 66.5799,0 0,12.7982 -80.9316,0" />
+        <path
+           inkscape:connector-curvature="0"
+           id="path6809"
+           style="fill:url(#linearGradient4029);font-family:Arial;-inkscape-font-specification:Arial"
+           d="m -1049.1342,1072.8942 41.9453,-56.519 -36.9888,-51.9323 17.0888,0 19.6781,27.8156 c 4.0934,5.77034 7.0032,10.209 8.72937,13.316 2.41655,-3.9454 5.27702,-8.06351 8.58141,-12.35429 l 21.82341,-28.77731 15.60929,0 -38.0985,51.1186 41.05761,57.3327 -17.75464,0 -27.29777,-38.6904 c -1.52892,-2.2192 -3.10711,-4.6358 -4.73457,-7.2498 -2.41661,3.9455 -4.14281,6.6581 -5.17841,8.1376 l -27.2238,37.8026 -17.2368,0" />
+        <path
+           inkscape:connector-curvature="0"
+           id="path6811"
+           style="fill:url(#linearGradient4031);font-family:Arial;-inkscape-font-specification:Arial"
+           d="m -909.46438,1072.8942 0,-95.65316 -35.73121,0 0,-12.79814 85.96205,0 0,12.79814 -35.87917,0 0,95.65316 -14.35167,0" />
+        <path
+           inkscape:connector-curvature="0"
+           id="path6813"
+           style="fill:url(#linearGradient4033);font-family:Arial;-inkscape-font-specification:Arial"
+           d="m -805.08185,1072.8942 0,-108.4513 37.35872,0 c 8.4334,1.1e-4 14.86945,0.51795 19.30817,1.55353 6.21405,1.43034 11.51578,4.01956 15.9052,7.76766 5.72085,4.8333 9.98689,11.02276 12.79814,18.56839 2.86037,7.49648 4.2906,16.07792 4.29071,25.74422 -1.1e-4,8.2362 -0.96181,15.5354 -2.88513,21.8974 -1.92352,6.3621 -4.38944,11.6392 -7.39777,15.8312 -3.00851,4.1428 -6.31285,7.4225 -9.91301,9.8391 -3.551,2.3672 -7.86636,4.1674 -12.94609,5.4003 -5.03055,1.233 -10.82546,1.8495 -17.38475,1.8495 l -39.13419,0 m 14.35167,-12.7982 23.15501,0 c 7.15112,0 12.74875,-0.6658 16.79293,-1.9974 4.09336,-1.3316 7.34837,-3.2057 9.76505,-5.6223 3.40289,-3.4029 6.04143,-7.9649 7.91561,-13.6858 1.92334,-5.7703 2.88504,-12.7488 2.88513,-20.9357 -9e-5,-11.3432 -1.87418,-20.0479 -5.6223,-26.11414 -3.69896,-6.1154 -8.2116,-10.20883 -13.53792,-12.28029 -3.8469,-1.47946 -10.03636,-2.21924 -18.56839,-2.21933 l -22.78512,0 0,82.85496" />
+        <path
+           inkscape:connector-curvature="0"
+           id="path6815"
+           style="fill:url(#linearGradient4035);font-family:Arial;-inkscape-font-specification:Arial"
+           d="m -707.57929,1072.8942 41.64943,-108.4513 15.46133,0 44.3866,108.4513 -16.34906,0 -12.65019,-32.8461 -45.34831,0 -11.9104,32.8461 -15.2394,0 m 31.29255,-44.5346 36.7669,0 -11.31858,-30.03493 c -3.45234,-9.12383 -6.0169,-16.62022 -7.69368,-22.48921 -1.38096,6.95399 -3.32904,13.85857 -5.84423,20.71375 l -11.91041,31.81039" />
+        <path
+           inkscape:connector-curvature="0"
+           id="path6817"
+           style="fill:url(#linearGradient4037);font-family:Arial;-inkscape-font-specification:Arial"
+           d="m -575.30721,1072.8942 0,-45.9402 -41.79739,-62.5111 17.45873,0 21.37955,32.69813 c 3.94543,6.11557 7.61965,12.23107 11.02267,18.34647 3.25497,-5.6716 7.20044,-12.0583 11.83643,-19.16023 l 21.00966,-31.88437 16.71895,0 -43.27693,62.5111 0,45.9402 -14.35167,0" />
+      </g>
+      <g
+         id="text3229"
+         style="font-size:244.91934204px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:url(#linearGradient4049);fill-opacity:1;stroke:#ff6600;stroke-width:5.43772173;font-family:Rufscript;-inkscape-font-specification:Rufscript">
+        <path
+           inkscape:connector-curvature="0"
+           id="path6822"
+           style="font-size:215.99368286px;font-weight:bold;text-align:start;line-height:125%;writing-mode:lr-tb;text-anchor:start;fill:url(#linearGradient4041);stroke:#ff6600;stroke-width:5.43241072;font-family:Arial Rounded MT Bold;-inkscape-font-specification:Arial Rounded MT Bold"
+           d="m -1159.6483,1179.1007 35.0159,103.4663 35.1214,-104.203 c 1.8281,-5.4732 3.1991,-9.2624 4.1134,-11.3676 0.9139,-2.1752 2.4257,-4.1048 4.5351,-5.7891 2.1093,-1.7541 4.9921,-2.6312 8.6486,-2.6314 2.6718,2e-4 5.1327,0.6667 7.3829,1.9999 2.3202,1.3333 4.1131,3.1226 5.3789,5.368 1.3358,2.1754 2.0039,4.3858 2.004,6.6311 -10e-5,1.5439 -0.2112,3.228 -0.6329,5.0523 -0.422,1.7543 -0.9493,3.5086 -1.582,5.2627 -0.633,1.6843 -1.2658,3.4385 -1.8985,5.2628 l -37.4418,100.8349 c -1.336,3.8594 -2.672,7.5434 -4.0078,11.0519 -1.3361,3.4383 -2.8829,6.4907 -4.6407,9.1572 -1.7579,2.5963 -4.1134,4.7365 -7.0665,6.4206 -2.8829,1.684 -6.4336,2.5262 -10.6524,2.5262 -4.2189,0 -7.8048,-0.8422 -10.7579,-2.5262 -2.8829,-1.6139 -5.2384,-3.7541 -7.0665,-6.4206 -1.7579,-2.7366 -3.3047,-5.8242 -4.6407,-9.2625 -1.3359,-3.4383 -2.6719,-7.0872 -4.0078,-10.9466 l -36.809,-99.9928 c -0.6328,-1.8243 -1.3007,-3.6137 -2.0039,-5.3681 -0.6328,-1.7541 -1.1953,-3.6487 -1.6875,-5.6838 -0.4219,-2.0348 -0.6329,-3.754 -0.6329,-5.1575 0,-3.5785 1.4415,-6.8414 4.3243,-9.7888 2.8828,-2.947 6.504,-4.4205 10.8634,-4.4207 5.3437,2e-4 9.1055,1.6492 11.2853,4.947 2.25,3.228 4.5352,8.4206 6.8556,15.5778" />
+        <path
+           inkscape:connector-curvature="0"
+           id="path6824"
+           style="font-size:215.99368286px;font-weight:bold;text-align:start;line-height:125%;writing-mode:lr-tb;text-anchor:start;fill:url(#linearGradient4043);stroke:#ff6600;stroke-width:5.43273163;font-family:Arial Rounded MT Bold;-inkscape-font-specification:Arial Rounded MT Bold"
+           d="m -1032.6689,1299.0921 0,-121.57 c 0,-6.3152 1.4416,-11.0516 4.3248,-14.2094 2.8832,-3.1575 6.6102,-4.7364 11.1812,-4.7366 4.7114,2e-4 8.5088,1.5791 11.3921,4.7366 2.9535,3.0876 4.4302,7.824 4.4302,14.2094 l 0,121.57 c 0,6.3855 -1.4767,11.1571 -4.4302,14.3148 -2.8833,3.1576 -6.6807,4.7365 -11.3921,4.7365 -4.5006,0 -8.2277,-1.5789 -11.1812,-4.7365 -2.8832,-3.2279 -4.3248,-7.9995 -4.3248,-14.3148" />
+        <path
+           inkscape:connector-curvature="0"
+           id="path6826"
+           style="font-size:215.99368286px;font-weight:bold;text-align:start;line-height:125%;writing-mode:lr-tb;text-anchor:start;fill:url(#linearGradient4045);stroke:#ff6600;stroke-width:5.52089787;font-family:Arial Rounded MT Bold;-inkscape-font-specification:Arial Rounded MT Bold"
+           d="m -946.89327,1158.6202 40.78952,0 c 10.6101,10e-5 19.70956,1.0155 27.29841,3.046 7.58863,2.0307 14.47472,5.8382 20.65826,11.4224 16.09082,14.2148 24.13628,35.8268 24.13643,64.836 -1.5e-4,9.5732 -0.8082,18.3123 -2.42418,26.2173 -1.61626,7.905 -4.11071,15.0486 -7.48335,21.4307 -3.37291,6.3095 -7.69427,11.9663 -12.96411,16.9704 -4.14582,3.8438 -8.67799,6.9261 -13.59651,9.2468 -4.91873,2.3208 -10.22383,3.9525 -15.91529,4.8954 -5.62139,0.9427 -11.98047,1.4141 -19.07727,1.4141 l -40.78952,0 c -5.6916,0 -9.97783,-0.8702 -12.85871,-2.6108 -2.88094,-1.8131 -4.77812,-4.3151 -5.69157,-7.5062 -0.84321,-3.2635 -1.2648,-7.4699 -1.26478,-12.6191 l 0,-116.9441 c -2e-5,-6.9621 1.5107,-12.0025 4.53216,-15.1211 3.02142,-3.1184 7.90492,-4.6777 14.65051,-4.6778 m 12.12091,25.5645 0,108.2413 23.71484,0 c 5.19962,10e-5 9.27506,-0.145 12.22632,-0.4351 2.95109,-0.29 6.00766,-1.0154 9.16973,-2.1757 3.16189,-1.1604 5.90226,-2.7922 8.22114,-4.8954 10.46956,-9.1379 15.70438,-24.8754 15.7045,-47.2128 -1.2e-4,-15.7375 -2.3189,-27.5225 -6.95636,-35.3551 -4.5674,-7.8324 -10.22382,-12.8003 -16.96928,-14.9036 -6.74564,-2.1756 -14.89651,-3.2635 -24.45263,-3.2636 l -20.65826,0" />
+        <path
+           inkscape:connector-curvature="0"
+           id="path6828"
+           style="font-size:215.99368286px;font-weight:bold;text-align:start;line-height:125%;writing-mode:lr-tb;text-anchor:start;fill:url(#linearGradient4047);stroke:#ff6600;stroke-width:5.52071571;font-family:Arial Rounded MT Bold;-inkscape-font-specification:Arial Rounded MT Bold"
+           d="m -704.59213,1183.5319 -70.5074,0 0,39.1627 64.92161,0 c 4.77766,10e-5 8.32587,1.1242 10.64461,3.3724 2.38877,2.1758 3.58322,5.0768 3.58335,8.7028 -1.3e-4,3.6263 -1.15945,6.5998 -3.47795,8.9204 -2.31875,2.2483 -5.90208,3.3724 -10.75001,3.3723 l -64.92161,0 0,45.3636 72.93142,0 c 4.91818,1e-4 8.6069,1.1967 11.06619,3.5899 2.52927,2.3208 3.79398,5.4393 3.79411,9.3555 -1.3e-4,3.7713 -1.26484,6.8535 -3.79411,9.2468 -2.45929,2.3208 -6.14801,3.4811 -11.06619,3.4811 l -85.05152,0 c -6.81539,0 -11.73369,-1.5592 -14.75491,-4.6777 -2.951,-3.1185 -4.42649,-8.1589 -4.42647,-15.1212 l 0,-119.8815 c -2e-5,-4.6413 0.66746,-8.4126 2.00245,-11.3136 1.33495,-2.9734 3.40766,-5.1129 6.21814,-6.4184 2.88069,-1.3778 6.53428,-2.0668 10.96079,-2.0669 l 82.6275,0 c 4.98844,10e-5 8.67717,1.1605 11.06619,3.4811 2.45901,2.2484 3.68859,5.2219 3.68873,8.9204 -1.4e-4,3.7714 -1.22972,6.8174 -3.68873,9.138 -2.38902,2.2483 -6.07775,3.3724 -11.06619,3.3723" />
+      </g>
+      <g
+         id="g3102">
+        <path
+           style="fill:url(#radialGradient4051);fill-opacity:1;fill-rule:evenodd;stroke:#ff6600;stroke-width:5.25925636"
+           d="m -631.69306,1158.4894 98.91466,0 c 16.84882,0 30.41304,13.5643 30.41304,30.413 l 0,98.9147 c 0,16.8487 -13.56422,30.413 -30.41304,30.413 l -98.91466,0 c -16.84883,0 -30.41305,-13.5643 -30.41305,-30.413 l 0,-98.9147 c 0,-16.8487 13.56422,-30.413 30.41305,-30.413 z"
+           id="rect3118"
+           inkscape:connector-curvature="0" />
+        <path
+           inkscape:connector-curvature="0"
+           style="font-size:xx-small;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-indent:0;text-align:start;text-decoration:none;line-height:normal;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;text-anchor:start;baseline-shift:baseline;color:#000000;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:26.75562668;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-family:Sans;-inkscape-font-specification:Sans"
+           d="m -584.43851,1173.3856 c -32.7794,0.9544 -59.34,27.3125 -60,62.5625 -0.6812,36.3871 25.3624,66.6821 59.5938,67.4062 l 0.125,-20.6875 c -23.4261,-0.4955 -40.1849,-21.4112 -39.7188,-46.3125 0.4662,-24.9014 19.6364,-43.0581 43.0626,-42.5625 23.4261,0.4955 41.8099,19.4737 41.3437,44.375 -0.2192,11.7074 -4.7241,22.8486 -12.5625,31.0625 l -3.5938,-3.4687 c -0.377,-0.3708 -0.9089,-0.5788 -1.4374,-0.5625 -1,0.045 -1.8786,0.9677 -1.875,1.9687 l 0,21 c 0,1.0212 0.9163,1.9551 1.9374,1.9688 l 21.7188,0 c 0.7781,0 1.5502,-0.4982 1.8438,-1.2188 0.2935,-0.7206 0.09,-1.6151 -0.4688,-2.1562 l -3.3438,-3.2188 c 11.0857,-12.0182 17.4655,-28.0993 17.7813,-44.9687 0.6812,-36.3872 -26.9873,-64.4633 -61.2187,-65.1875 -1.0698,-0.023 -2.1301,-0.031 -3.1876,0 z"
+           id="path3120" />
+        <path
+           style="fill:#2f2f36;fill-opacity:1;stroke:#2f2f36;stroke-width:8.25762749;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dashoffset:0"
+           inkscape:transform-center-x="-3.965261"
+           inkscape:transform-center-y="-3.8026582e-05"
+           d="m -563.84011,1238.3159 -23.35884,20.6008 0,-41.2016 z"
+           id="path6234"
+           inkscape:connector-curvature="0" />
+      </g>
+    </g>
+    <g
+       id="layer1-9"
+       transform="matrix(0.53934861,0,0,0.53934861,493.46233,451.10768)"
+       style="fill:#ffffff"
+       inkscape:export-filename="/home/cats/Desktop/pyohio.png"
+       inkscape:export-xdpi="71.95591"
+       inkscape:export-ydpi="71.95591">
+      <path
+         style="fill:#f5f2dc;fill-opacity:1;stroke:none"
+         id="path238"
+         d="m 385.81869,743.0644 -13.46875,60.78125 17.90625,0 8.25,-32.90625 0.625,32.90625 12.625,0 16.375,-32.90625 -7.21875,32.90625 17.15625,0 13.53125,-60.78125 -24.09375,0 -16.09375,33.65625 -1.25,-33.65625 -24.34375,0 z m 69.1875,0 -2.09375,9.21875 16.09375,0 1.8125,-9.21875 -15.8125,0 z m 250.5625,0.96875 c -3.77195,0.10375 -8.04621,0.61621 -10.09375,2.28125 -5.2751,4.16008 -6.25,12.41749 -6.25,12.5625 l -6.5,0 -2.375,9.28125 c -2.72722,-6.04447 -8.6036,-10.56377 -18.09375,-11.15625 -32.19063,-1.94504 -42.95938,46.20122 -10.96875,47.65625 23.49257,1.10207 35.11206,-21.09277 29.4375,-35.59375 l 6.5,0 -8.3125,34.71875 16.34375,0 7.78125,-34.71875 6.03125,0 -5.40625,24.65625 c -0.41501,2.63505 0.15497,4.96995 1.75,7.125 2.50005,3.25506 5.53124,2.9375 6.78125,2.9375 l 11.8125,0 2.6875,-11.53125 c 0,0 -5.47499,0.76127 -6.375,-0.34375 -0.76002,-0.97002 -0.20501,-2.29123 0,-3.40625 l 4.375,-19 5.6875,0 2.5,-10.34375 -5.625,0 2.28125,-10.6875 -15.75,0 -2.5,10.6875 -6.3125,0 c 0,0 0.69374,-4.44874 1.59375,-5.34375 1.18002,-1.18003 4.25,-1.1875 4.25,-1.1875 l 1.78125,-8.375 c 0,0 -3.2593,-0.32251 -7.03125,-0.21875 z m -138,12.9375 c -11.05091,0.0321 -19.43052,5.88517 -24.28125,13.5 l 2.8125,-12.5625 c -7.91015,0.07 -12.27122,3.4062 -14.28125,5.90625 l 1.25,-5.15625 -15.75,0.625 -10.40625,44.5625 16.84375,0 3.53125,-17.78125 c 1.28374,-6.47703 3.71168,-12.26357 14.5625,-13.09375 -6.8424,13.32891 -3.49236,30.41789 14.15625,32.1875 20.9554,2.01004 27.46875,-14.90625 27.46875,-14.90625 0,0 -3.10672,14.96999 21.59375,15.25 23.10045,0.28 25.37375,-15.05244 25.09375,-18.3125 -0.90001,-11.58523 -10.87358,-11.87247 -20.09375,-13.8125 -7.49514,-1.59504 -5.54387,-7.2975 0.28125,-7.4375 7.36015,-0.13501 5.40625,5.90625 5.40625,5.90625 l 15.75,0 c -0.345,-0.90502 4.38545,-14.84375 -19,-14.84375 -10.75521,0 -21.57872,3.52732 -22.96875,12.6875 -1.94503,12.76524 13.24117,15.18623 17.40625,16.15625 8.60516,1.87503 7.35515,8.75124 0,9.03125 -9.16018,0.28 -6.53125,-7.0625 -6.53125,-7.0625 l -27.75,0 c 0,0 14.21624,-4.78876 14.28125,-4.71875 2.70505,-8.46017 1.13537,-25.32874 -17.875,-26.09375 -0.49876,-0.0216 -1.01158,-0.0327 -1.5,-0.0312 z m -73.875,0.40625 c -33.60366,-0.15672 -39.154,47.79179 -10.46875,48.0625 22.69044,0.21 25.53125,-18.0325 25.53125,-18.3125 l -14.6875,0 c -0.41501,0.69501 -2.77115,6.3125 -7.90625,6.3125 -10.33521,0 -2.92391,-24.7875 6.03125,-25.0625 5.41011,-0.21001 4.5625,6.93624 4.5625,7.28125 l 14.78125,0 c 0,-0.41501 0.57157,-17.34999 -16.21875,-18.25 -0.54751,-0.0271 -1.09161,-0.0289 -1.625,-0.0312 z m -42.3125,1.09375 -10.125,45.4375 16.65625,0 9.71875,-45.4375 -16.25,0 z m 291.96875,0 c -8.39517,0 -8.39517,12.46875 0,12.46875 8.40016,0 8.40016,-12.46875 0,-12.46875 z m 0,1.09375 c 7.08014,0 7.08014,10.21875 0,10.21875 -7.00514,0 -7.00514,-10.21875 0,-10.21875 z m -1.59375,1.875 -1.03125,6.65625 1.25,0 0.40625,-2.6875 0.84375,0 1.03125,2.5 1.46875,0 -1.25,-2.5 c 0.135,0 1.67,3e-5 1.875,-1.875 0.14,-1.66504 -1.53125,-2.09375 -1.53125,-2.09375 l -3.0625,0 z m 1.1875,0.90625 1.25,0 c 0,0 1.03125,0.01 1.03125,1.125 -0.135,1.24502 -1.375,1.03125 -1.375,1.03125 l -1.25,0 0.34375,-2.15625 z m -83.3125,5.125 c 0.54511,-0.0308 1.10124,0.0412 1.65625,0.21875 8.88019,2.78005 1.01393,28.91631 -8.28125,25.65625 -8.19391,-2.92506 -1.55158,-25.41368 6.625,-25.875 z m -93.125,0.0937 c 0.54712,-0.037 1.10968,0.0228 1.65625,0.1875 8.81517,2.77505 0.83144,28.78881 -8.46875,25.59375 -9.10798,-3.31882 -1.39431,-25.22638 6.8125,-25.78125 z"
+         inkscape:connector-curvature="0" />
+    </g>
+    <text
+       sodipodi:linespacing="125%"
+       id="text3740"
+       y="806.95599"
+       x="879.27997"
+       style="font-size:29.07887077px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-align:end;line-height:125%;letter-spacing:0px;word-spacing:0px;text-anchor:end;fill:#ff934c;fill-opacity:1;stroke:none;font-family:Purisa;-inkscape-font-specification:Purisa"
+       xml:space="preserve"
+       inkscape:export-filename="/home/cats/Desktop/pyohio.png"
+       inkscape:export-xdpi="71.95591"
+       inkscape:export-ydpi="71.95591"><tspan
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;fill:#ff934c;fill-opacity:1;font-family:Corabael;-inkscape-font-specification:Corabael"
+         y="806.95599"
+         x="896.12372"
+         id="tspan3742"
+         sodipodi:role="line"><tspan
+           id="tspan3744"
+           style="font-size:40px;fill:#ff934c;fill-opacity:1"><tspan
+             dy="11.062947 0 0 0 0 -11.062947"
+             dx="-28.763662 0 0 0 0 28.763662"
+             id="tspan3746"
+             style="font-size:56px;fill:#ff934c;fill-opacity:1">video </tspan></tspan></tspan><tspan
+         dx="25.444778"
+         dy="-16.594421"
+         id="tspan3748"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;fill:#ff934c;fill-opacity:1;font-family:Corabael;-inkscape-font-specification:Corabael"
+         y="855.49255"
+         x="879.27997"
+         sodipodi:role="line">sponsored by</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-size:31.8769722px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-align:end;line-height:125%;letter-spacing:0px;word-spacing:0px;text-anchor:end;fill:#ff934c;fill-opacity:1;stroke:none;font-family:Purisa;-inkscape-font-specification:Purisa"
+       x="320.77899"
+       y="893.90979"
+       id="text4147"
+       sodipodi:linespacing="125%"
+       inkscape:export-filename="/home/cats/Desktop/pyohio.png"
+       inkscape:export-xdpi="71.95591"
+       inkscape:export-ydpi="71.95591"><tspan
+         sodipodi:role="line"
+         x="330.36697"
+         y="893.90979"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;fill:#ff934c;fill-opacity:1;font-family:Corabael;-inkscape-font-specification:Corabael"
+         id="tspan4170">produced by </tspan></text>
+    <g
+       id="g3263"
+       transform="matrix(0.74117269,0,0,0.74117269,44.780328,98.030485)"
+       inkscape:export-filename="/home/cats/Desktop/pyohio.png"
+       inkscape:export-xdpi="71.95591"
+       inkscape:export-ydpi="71.95591">
+      <g
+         transform="matrix(0.86536424,0,0,0.86536424,-458.4434,38.61852)"
+         id="g3210">
         <g
-           transform="translate(0,70.639215)"
-           id="g6241">
-          <g
-             id="text3233"
-             style="font-size:151.50627136px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:url(#linearGradient7027);fill-opacity:1;stroke:none;font-family:Arial;-inkscape-font-specification:Arial"
-             transform="matrix(1.2311103,0,0,1.4753166,-617.37357,-261.99886)">
-            <path
-               inkscape:connector-curvature="0"
-               id="path6805"
-               style="fill:url(#linearGradient7013);font-family:Arial;-inkscape-font-specification:Arial"
-               d="m -1248.726,1072.8942 0,-108.4513 14.7216,0 56.9628,85.1483 0,-85.1483 13.7598,0 0,108.4513 -14.7215,0 -56.9628,-85.22231 0,85.22231 -13.7599,0" />
-            <path
-               inkscape:connector-curvature="0"
-               id="path6807"
-               style="fill:url(#linearGradient7015);font-family:Arial;-inkscape-font-specification:Arial"
-               d="m -1138.8691,1072.8942 0,-108.4513 78.4163,0 0,12.79814 -64.0646,0 0,33.21596 59.9958,0 0,12.7242 -59.9958,0 0,36.9148 66.5799,0 0,12.7982 -80.9316,0" />
-            <path
-               inkscape:connector-curvature="0"
-               id="path6809"
-               style="fill:url(#linearGradient7017);font-family:Arial;-inkscape-font-specification:Arial"
-               d="m -1049.1342,1072.8942 41.9453,-56.519 -36.9888,-51.9323 17.0888,0 19.6781,27.8156 c 4.0934,5.77034 7.0032,10.209 8.72937,13.316 2.41655,-3.9454 5.27702,-8.06351 8.58141,-12.35429 l 21.82341,-28.77731 15.60929,0 -38.0985,51.1186 41.05761,57.3327 -17.75464,0 -27.29777,-38.6904 c -1.52892,-2.2192 -3.10711,-4.6358 -4.73457,-7.2498 -2.41661,3.9455 -4.14281,6.6581 -5.17841,8.1376 l -27.2238,37.8026 -17.2368,0" />
-            <path
-               inkscape:connector-curvature="0"
-               id="path6811"
-               style="fill:url(#linearGradient7019);font-family:Arial;-inkscape-font-specification:Arial"
-               d="m -909.46438,1072.8942 0,-95.65316 -35.73121,0 0,-12.79814 85.96205,0 0,12.79814 -35.87917,0 0,95.65316 -14.35167,0" />
-            <path
-               inkscape:connector-curvature="0"
-               id="path6813"
-               style="fill:url(#linearGradient7021);font-family:Arial;-inkscape-font-specification:Arial"
-               d="m -805.08185,1072.8942 0,-108.4513 37.35872,0 c 8.4334,1.1e-4 14.86945,0.51795 19.30817,1.55353 6.21405,1.43034 11.51578,4.01956 15.9052,7.76766 5.72085,4.8333 9.98689,11.02276 12.79814,18.56839 2.86037,7.49648 4.2906,16.07792 4.29071,25.74422 -1.1e-4,8.2362 -0.96181,15.5354 -2.88513,21.8974 -1.92352,6.3621 -4.38944,11.6392 -7.39777,15.8312 -3.00851,4.1428 -6.31285,7.4225 -9.91301,9.8391 -3.551,2.3672 -7.86636,4.1674 -12.94609,5.4003 -5.03055,1.233 -10.82546,1.8495 -17.38475,1.8495 l -39.13419,0 m 14.35167,-12.7982 23.15501,0 c 7.15112,0 12.74875,-0.6658 16.79293,-1.9974 4.09336,-1.3316 7.34837,-3.2057 9.76505,-5.6223 3.40289,-3.4029 6.04143,-7.9649 7.91561,-13.6858 1.92334,-5.7703 2.88504,-12.7488 2.88513,-20.9357 -9e-5,-11.3432 -1.87418,-20.0479 -5.6223,-26.11414 -3.69896,-6.1154 -8.2116,-10.20883 -13.53792,-12.28029 -3.8469,-1.47946 -10.03636,-2.21924 -18.56839,-2.21933 l -22.78512,0 0,82.85496" />
-            <path
-               inkscape:connector-curvature="0"
-               id="path6815"
-               style="fill:url(#linearGradient7023);font-family:Arial;-inkscape-font-specification:Arial"
-               d="m -707.57929,1072.8942 41.64943,-108.4513 15.46133,0 44.3866,108.4513 -16.34906,0 -12.65019,-32.8461 -45.34831,0 -11.9104,32.8461 -15.2394,0 m 31.29255,-44.5346 36.7669,0 -11.31858,-30.03493 c -3.45234,-9.12383 -6.0169,-16.62022 -7.69368,-22.48921 -1.38096,6.95399 -3.32904,13.85857 -5.84423,20.71375 l -11.91041,31.81039" />
-            <path
-               inkscape:connector-curvature="0"
-               id="path6817"
-               style="fill:url(#linearGradient7025);font-family:Arial;-inkscape-font-specification:Arial"
-               d="m -575.30721,1072.8942 0,-45.9402 -41.79739,-62.5111 17.45873,0 21.37955,32.69813 c 3.94543,6.11557 7.61965,12.23107 11.02267,18.34647 3.25497,-5.6716 7.20044,-12.0583 11.83643,-19.16023 l 21.00966,-31.88437 16.71895,0 -43.27693,62.5111 0,45.9402 -14.35167,0" />
-          </g>
-          <g
-             id="text3229"
-             style="font-size:244.91934204px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:url(#linearGradient7037);fill-opacity:1;stroke:#ff6600;stroke-width:5.43772173;font-family:Rufscript;-inkscape-font-specification:Rufscript">
-            <path
-               inkscape:connector-curvature="0"
-               id="path6822"
-               style="font-size:215.99368286px;font-weight:bold;text-align:start;line-height:125%;writing-mode:lr-tb;text-anchor:start;fill:url(#linearGradient7029);stroke:#ff6600;stroke-width:5.43241072;font-family:Arial Rounded MT Bold;-inkscape-font-specification:Arial Rounded MT Bold"
-               d="m -1159.6483,1179.1007 35.0159,103.4663 35.1214,-104.203 c 1.8281,-5.4732 3.1991,-9.2624 4.1134,-11.3676 0.9139,-2.1752 2.4257,-4.1048 4.5351,-5.7891 2.1093,-1.7541 4.9921,-2.6312 8.6486,-2.6314 2.6718,2e-4 5.1327,0.6667 7.3829,1.9999 2.3202,1.3333 4.1131,3.1226 5.3789,5.368 1.3358,2.1754 2.0039,4.3858 2.004,6.6311 -10e-5,1.5439 -0.2112,3.228 -0.6329,5.0523 -0.422,1.7543 -0.9493,3.5086 -1.582,5.2627 -0.633,1.6843 -1.2658,3.4385 -1.8985,5.2628 l -37.4418,100.8349 c -1.336,3.8594 -2.672,7.5434 -4.0078,11.0519 -1.3361,3.4383 -2.8829,6.4907 -4.6407,9.1572 -1.7579,2.5963 -4.1134,4.7365 -7.0665,6.4206 -2.8829,1.684 -6.4336,2.5262 -10.6524,2.5262 -4.2189,0 -7.8048,-0.8422 -10.7579,-2.5262 -2.8829,-1.6139 -5.2384,-3.7541 -7.0665,-6.4206 -1.7579,-2.7366 -3.3047,-5.8242 -4.6407,-9.2625 -1.3359,-3.4383 -2.6719,-7.0872 -4.0078,-10.9466 l -36.809,-99.9928 c -0.6328,-1.8243 -1.3007,-3.6137 -2.0039,-5.3681 -0.6328,-1.7541 -1.1953,-3.6487 -1.6875,-5.6838 -0.4219,-2.0348 -0.6329,-3.754 -0.6329,-5.1575 0,-3.5785 1.4415,-6.8414 4.3243,-9.7888 2.8828,-2.947 6.504,-4.4205 10.8634,-4.4207 5.3437,2e-4 9.1055,1.6492 11.2853,4.947 2.25,3.228 4.5352,8.4206 6.8556,15.5778" />
-            <path
-               inkscape:connector-curvature="0"
-               id="path6824"
-               style="font-size:215.99368286px;font-weight:bold;text-align:start;line-height:125%;writing-mode:lr-tb;text-anchor:start;fill:url(#linearGradient7031);stroke:#ff6600;stroke-width:5.43273163;font-family:Arial Rounded MT Bold;-inkscape-font-specification:Arial Rounded MT Bold"
-               d="m -1032.6689,1299.0921 0,-121.57 c 0,-6.3152 1.4416,-11.0516 4.3248,-14.2094 2.8832,-3.1575 6.6102,-4.7364 11.1812,-4.7366 4.7114,2e-4 8.5088,1.5791 11.3921,4.7366 2.9535,3.0876 4.4302,7.824 4.4302,14.2094 l 0,121.57 c 0,6.3855 -1.4767,11.1571 -4.4302,14.3148 -2.8833,3.1576 -6.6807,4.7365 -11.3921,4.7365 -4.5006,0 -8.2277,-1.5789 -11.1812,-4.7365 -2.8832,-3.2279 -4.3248,-7.9995 -4.3248,-14.3148" />
-            <path
-               inkscape:connector-curvature="0"
-               id="path6826"
-               style="font-size:215.99368286px;font-weight:bold;text-align:start;line-height:125%;writing-mode:lr-tb;text-anchor:start;fill:url(#linearGradient7033);stroke:#ff6600;stroke-width:5.52089787;font-family:Arial Rounded MT Bold;-inkscape-font-specification:Arial Rounded MT Bold"
-               d="m -946.89327,1158.6202 40.78952,0 c 10.6101,10e-5 19.70956,1.0155 27.29841,3.046 7.58863,2.0307 14.47472,5.8382 20.65826,11.4224 16.09082,14.2148 24.13628,35.8268 24.13643,64.836 -1.5e-4,9.5732 -0.8082,18.3123 -2.42418,26.2173 -1.61626,7.905 -4.11071,15.0486 -7.48335,21.4307 -3.37291,6.3095 -7.69427,11.9663 -12.96411,16.9704 -4.14582,3.8438 -8.67799,6.9261 -13.59651,9.2468 -4.91873,2.3208 -10.22383,3.9525 -15.91529,4.8954 -5.62139,0.9427 -11.98047,1.4141 -19.07727,1.4141 l -40.78952,0 c -5.6916,0 -9.97783,-0.8702 -12.85871,-2.6108 -2.88094,-1.8131 -4.77812,-4.3151 -5.69157,-7.5062 -0.84321,-3.2635 -1.2648,-7.4699 -1.26478,-12.6191 l 0,-116.9441 c -2e-5,-6.9621 1.5107,-12.0025 4.53216,-15.1211 3.02142,-3.1184 7.90492,-4.6777 14.65051,-4.6778 m 12.12091,25.5645 0,108.2413 23.71484,0 c 5.19962,10e-5 9.27506,-0.145 12.22632,-0.4351 2.95109,-0.29 6.00766,-1.0154 9.16973,-2.1757 3.16189,-1.1604 5.90226,-2.7922 8.22114,-4.8954 10.46956,-9.1379 15.70438,-24.8754 15.7045,-47.2128 -1.2e-4,-15.7375 -2.3189,-27.5225 -6.95636,-35.3551 -4.5674,-7.8324 -10.22382,-12.8003 -16.96928,-14.9036 -6.74564,-2.1756 -14.89651,-3.2635 -24.45263,-3.2636 l -20.65826,0" />
-            <path
-               inkscape:connector-curvature="0"
-               id="path6828"
-               style="font-size:215.99368286px;font-weight:bold;text-align:start;line-height:125%;writing-mode:lr-tb;text-anchor:start;fill:url(#linearGradient7035);stroke:#ff6600;stroke-width:5.52071571;font-family:Arial Rounded MT Bold;-inkscape-font-specification:Arial Rounded MT Bold"
-               d="m -704.59213,1183.5319 -70.5074,0 0,39.1627 64.92161,0 c 4.77766,10e-5 8.32587,1.1242 10.64461,3.3724 2.38877,2.1758 3.58322,5.0768 3.58335,8.7028 -1.3e-4,3.6263 -1.15945,6.5998 -3.47795,8.9204 -2.31875,2.2483 -5.90208,3.3724 -10.75001,3.3723 l -64.92161,0 0,45.3636 72.93142,0 c 4.91818,1e-4 8.6069,1.1967 11.06619,3.5899 2.52927,2.3208 3.79398,5.4393 3.79411,9.3555 -1.3e-4,3.7713 -1.26484,6.8535 -3.79411,9.2468 -2.45929,2.3208 -6.14801,3.4811 -11.06619,3.4811 l -85.05152,0 c -6.81539,0 -11.73369,-1.5592 -14.75491,-4.6777 -2.951,-3.1185 -4.42649,-8.1589 -4.42647,-15.1212 l 0,-119.8815 c -2e-5,-4.6413 0.66746,-8.4126 2.00245,-11.3136 1.33495,-2.9734 3.40766,-5.1129 6.21814,-6.4184 2.88069,-1.3778 6.53428,-2.0668 10.96079,-2.0669 l 82.6275,0 c 4.98844,10e-5 8.67717,1.1605 11.06619,3.4811 2.45901,2.2484 3.68859,5.2219 3.68873,8.9204 -1.4e-4,3.7714 -1.22972,6.8174 -3.68873,9.138 -2.38902,2.2483 -6.07775,3.3724 -11.06619,3.3723" />
-          </g>
-          <g
-             id="g3102">
-            <path
-               style="fill:url(#radialGradient6379);fill-opacity:1;fill-rule:evenodd;stroke:#ff6600;stroke-width:5.25925636"
-               d="m -631.69306,1158.4894 98.91466,0 c 16.84882,0 30.41304,13.5643 30.41304,30.413 l 0,98.9147 c 0,16.8487 -13.56422,30.413 -30.41304,30.413 l -98.91466,0 c -16.84883,0 -30.41305,-13.5643 -30.41305,-30.413 l 0,-98.9147 c 0,-16.8487 13.56422,-30.413 30.41305,-30.413 z"
-               id="rect3118"
-               inkscape:connector-curvature="0" />
-            <path
-               inkscape:connector-curvature="0"
-               style="font-size:medium;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-indent:0;text-align:start;text-decoration:none;line-height:normal;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;text-anchor:start;baseline-shift:baseline;color:#000000;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:26.75562668;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-family:Sans;-inkscape-font-specification:Sans"
-               d="m -584.43851,1173.3856 c -32.7794,0.9544 -59.34,27.3125 -60,62.5625 -0.6812,36.3871 25.3624,66.6821 59.5938,67.4062 l 0.125,-20.6875 c -23.4261,-0.4955 -40.1849,-21.4112 -39.7188,-46.3125 0.4662,-24.9014 19.6364,-43.0581 43.0626,-42.5625 23.4261,0.4955 41.8099,19.4737 41.3437,44.375 -0.2192,11.7074 -4.7241,22.8486 -12.5625,31.0625 l -3.5938,-3.4687 c -0.377,-0.3708 -0.9089,-0.5788 -1.4374,-0.5625 -1,0.045 -1.8786,0.9677 -1.875,1.9687 l 0,21 c 0,1.0212 0.9163,1.9551 1.9374,1.9688 l 21.7188,0 c 0.7781,0 1.5502,-0.4982 1.8438,-1.2188 0.2935,-0.7206 0.09,-1.6151 -0.4688,-2.1562 l -3.3438,-3.2188 c 11.0857,-12.0182 17.4655,-28.0993 17.7813,-44.9687 0.6812,-36.3872 -26.9873,-64.4633 -61.2187,-65.1875 -1.0698,-0.023 -2.1301,-0.031 -3.1876,0 z"
-               id="path3120" />
-            <path
-               style="fill:#2f2f36;fill-opacity:1;stroke:#2f2f36;stroke-width:8.25762749;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dashoffset:0"
-               inkscape:transform-center-x="-3.965261"
-               inkscape:transform-center-y="-3.8026582e-05"
-               d="m -563.84011,1238.3159 -23.35884,20.6008 0,-41.2016 z"
-               id="path6234"
-               inkscape:connector-curvature="0" />
-          </g>
+           id="flowRoot3202"
+           style="font-size:40px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-align:end;line-height:125%;letter-spacing:0px;word-spacing:0px;text-anchor:end;fill:#434242;fill-opacity:1;stroke:none;font-family:Purisa;-inkscape-font-specification:Purisa"
+           transform="matrix(4.074181,0,0,4.074181,1356.5496,-764.74546)">
+          <path
+             id="path3238"
+             style="fill:#434242;font-family:League Gothic;-inkscape-font-specification:League Gothic"
+             d="m -96.61875,319.96928 4.32,0 0,-11.76 c 3.76,0 7.6,-2.08 7.6,-8.84 0,-6.76 -3.84,-8.8 -7.6,-8.8 -0.2,0 -4.32,0 -4.32,0 l 0,29.4 z m 4.32,-25 c 2.72,0 3.24,1.28 3.24,4.56 0,3.28 -0.52,4.28 -3.24,4.28 l 0,-8.84 z"
+             inkscape:connector-curvature="0" />
+          <path
+             id="path3240"
+             style="fill:#434242;font-family:League Gothic;-inkscape-font-specification:League Gothic"
+             d="m -83.51625,327.72928 c 0,0 1.36,0.08 1.8,0.08 3.2,0 5.2,-3.16 5.6,-6.2 l 3.88,-23.52 -3.96,0 -1.6,13.44 -0.08,1.12 -0.16,0 -0.08,-1.12 -1.6,-13.44 -3.96,0 3.72,22.52 c 0,1.6 -0.92,3.44 -2.6,3.6 -0.64,0 -0.96,-0.08 -0.96,-0.08 l 0,3.6 z"
+             inkscape:connector-curvature="0" />
+          <path
+             id="path3242"
+             style="fill:#434242;font-family:League Gothic;-inkscape-font-specification:League Gothic"
+             d="m -58.9725,313.92928 0,-17.32 c 0,0 0.04,-6.36 -5.76,-6.36 -5.8,0 -5.76,6.36 -5.76,6.36 l 0,17.32 c 0,0 -0.04,6.36 5.76,6.36 5.8,0 5.76,-6.36 5.76,-6.36 z m -4.32,-17.32 0,17.32 c 0,0 0.08,2.16 -1.44,2.16 -1.52,0 -1.44,-2.16 -1.44,-2.16 l 0,-17.32 c 0,0 -0.08,-2.16 1.44,-2.16 1.52,0 1.44,2.16 1.44,2.16 z"
+             inkscape:connector-curvature="0" />
+          <path
+             id="path3244"
+             style="fill:#434242;font-family:League Gothic;-inkscape-font-specification:League Gothic"
+             d="m -48.391875,319.96928 4.32,0 0,-29.4 -4.32,0 0,12.16 -3.36,0 0,-12.16 -4.32,0 c 0,0.2 0,29.4 0,29.4 l 4.32,0 0,-12.8 3.36,0 0,12.8 z"
+             inkscape:connector-curvature="0" />
+          <path
+             id="path3246"
+             style="fill:#434242;font-family:League Gothic;-inkscape-font-specification:League Gothic"
+             d="m -40.99375,319.96928 4.32,0 0,-29.4 -4.32,0 0,29.4 z"
+             inkscape:connector-curvature="0" />
+          <path
+             id="path3248"
+             style="fill:#434242;font-family:League Gothic;-inkscape-font-specification:League Gothic"
+             d="m -22.331875,313.92928 0,-17.32 c 0,0 0.04,-6.36 -5.76,-6.36 -5.8,0 -5.76,6.36 -5.76,6.36 l 0,17.32 c 0,0 -0.04,6.36 5.76,6.36 5.8,0 5.76,-6.36 5.76,-6.36 z m -4.32,-17.32 0,17.32 c 0,0 0.08,2.16 -1.44,2.16 -1.52,0 -1.44,-2.16 -1.44,-2.16 l 0,-17.32 c 0,0 -0.08,-2.16 1.44,-2.16 1.52,0 1.44,2.16 1.44,2.16 z"
+             inkscape:connector-curvature="0" />
+        </g>
+        <g
+           id="flowRoot3165"
+           style="font-size:40px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-align:end;line-height:125%;letter-spacing:0px;word-spacing:0px;text-anchor:end;fill:#d31805;fill-opacity:1;stroke:none;font-family:Purisa;-inkscape-font-specification:Purisa"
+           transform="matrix(4.0811799,0,0,4.0811799,1364.5047,-761.06061)">
+          <path
+             id="path3251"
+             style="fill:#d31805;font-family:League Gothic;-inkscape-font-specification:League Gothic"
+             d="m -96.61875,319.96928 4.32,0 0,-11.76 c 3.76,0 7.6,-2.08 7.6,-8.84 0,-6.76 -3.84,-8.8 -7.6,-8.8 -0.2,0 -4.32,0 -4.32,0 l 0,29.4 z m 4.32,-25 c 2.72,0 3.24,1.28 3.24,4.56 0,3.28 -0.52,4.28 -3.24,4.28 l 0,-8.84 z"
+             inkscape:connector-curvature="0" />
+          <path
+             id="path3253"
+             style="fill:#d31805;font-family:League Gothic;-inkscape-font-specification:League Gothic"
+             d="m -83.51625,327.72928 c 0,0 1.36,0.08 1.8,0.08 3.2,0 5.2,-3.16 5.6,-6.2 l 3.88,-23.52 -3.96,0 -1.6,13.44 -0.08,1.12 -0.16,0 -0.08,-1.12 -1.6,-13.44 -3.96,0 3.72,22.52 c 0,1.6 -0.92,3.44 -2.6,3.6 -0.64,0 -0.96,-0.08 -0.96,-0.08 l 0,3.6 z"
+             inkscape:connector-curvature="0" />
+          <path
+             id="path3255"
+             style="fill:#d31805;font-family:League Gothic;-inkscape-font-specification:League Gothic"
+             d="m -58.9725,313.92928 0,-17.32 c 0,0 0.04,-6.36 -5.76,-6.36 -5.8,0 -5.76,6.36 -5.76,6.36 l 0,17.32 c 0,0 -0.04,6.36 5.76,6.36 5.8,0 5.76,-6.36 5.76,-6.36 z m -4.32,-17.32 0,17.32 c 0,0 0.08,2.16 -1.44,2.16 -1.52,0 -1.44,-2.16 -1.44,-2.16 l 0,-17.32 c 0,0 -0.08,-2.16 1.44,-2.16 1.52,0 1.44,2.16 1.44,2.16 z"
+             inkscape:connector-curvature="0" />
+          <path
+             id="path3257"
+             style="fill:#d31805;font-family:League Gothic;-inkscape-font-specification:League Gothic"
+             d="m -48.391875,319.96928 4.32,0 0,-29.4 -4.32,0 0,12.16 -3.36,0 0,-12.16 -4.32,0 c 0,0.2 0,29.4 0,29.4 l 4.32,0 0,-12.8 3.36,0 0,12.8 z"
+             inkscape:connector-curvature="0" />
+          <path
+             id="path3259"
+             style="fill:#d31805;font-family:League Gothic;-inkscape-font-specification:League Gothic"
+             d="m -40.99375,319.96928 4.32,0 0,-29.4 -4.32,0 0,29.4 z"
+             inkscape:connector-curvature="0" />
+          <path
+             id="path3261"
+             style="fill:#d31805;font-family:League Gothic;-inkscape-font-specification:League Gothic"
+             d="m -22.331875,313.92928 0,-17.32 c 0,0 0.04,-6.36 -5.76,-6.36 -5.8,0 -5.76,6.36 -5.76,6.36 l 0,17.32 c 0,0 -0.04,6.36 5.76,6.36 5.8,0 5.76,-6.36 5.76,-6.36 z m -4.32,-17.32 0,17.32 c 0,0 0.08,2.16 -1.44,2.16 -1.52,0 -1.44,-2.16 -1.44,-2.16 l 0,-17.32 c 0,0 -0.08,-2.16 1.44,-2.16 1.52,0 1.44,2.16 1.44,2.16 z"
+             inkscape:connector-curvature="0" />
+        </g>
+        <g
+           id="flowRoot3192"
+           style="font-size:40px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-align:end;line-height:125%;letter-spacing:0px;word-spacing:0px;text-anchor:end;fill:#ffffff;fill-opacity:1;stroke:none;font-family:Purisa;-inkscape-font-specification:Purisa"
+           transform="matrix(4.0951776,0,0,4.0951776,1361.9005,-768.63758)">
+          <path
+             id="path3225"
+             style="fill:#f5f2dc;font-family:League Gothic;-inkscape-font-specification:League Gothic;fill-opacity:1"
+             d="m -96.61875,319.96928 4.32,0 0,-11.76 c 3.76,0 7.6,-2.08 7.6,-8.84 0,-6.76 -3.84,-8.8 -7.6,-8.8 -0.2,0 -4.32,0 -4.32,0 l 0,29.4 z m 4.32,-25 c 2.72,0 3.24,1.28 3.24,4.56 0,3.28 -0.52,4.28 -3.24,4.28 l 0,-8.84 z"
+             inkscape:connector-curvature="0" />
+          <path
+             id="path3227"
+             style="fill:#f5f2dc;font-family:League Gothic;-inkscape-font-specification:League Gothic;fill-opacity:1"
+             d="m -83.51625,327.72928 c 0,0 1.36,0.08 1.8,0.08 3.2,0 5.2,-3.16 5.6,-6.2 l 3.88,-23.52 -3.96,0 -1.6,13.44 -0.08,1.12 -0.16,0 -0.08,-1.12 -1.6,-13.44 -3.96,0 3.72,22.52 c 0,1.6 -0.92,3.44 -2.6,3.6 -0.64,0 -0.96,-0.08 -0.96,-0.08 l 0,3.6 z"
+             inkscape:connector-curvature="0" />
+          <path
+             id="path3229"
+             style="fill:#f5f2dc;font-family:League Gothic;-inkscape-font-specification:League Gothic;fill-opacity:1"
+             d="m -58.9725,313.92928 0,-17.32 c 0,0 0.04,-6.36 -5.76,-6.36 -5.8,0 -5.76,6.36 -5.76,6.36 l 0,17.32 c 0,0 -0.04,6.36 5.76,6.36 5.8,0 5.76,-6.36 5.76,-6.36 z m -4.32,-17.32 0,17.32 c 0,0 0.08,2.16 -1.44,2.16 -1.52,0 -1.44,-2.16 -1.44,-2.16 l 0,-17.32 c 0,0 -0.08,-2.16 1.44,-2.16 1.52,0 1.44,2.16 1.44,2.16 z"
+             inkscape:connector-curvature="0" />
+          <path
+             id="path3231"
+             style="fill:#f5f2dc;font-family:League Gothic;-inkscape-font-specification:League Gothic;fill-opacity:1"
+             d="m -48.391875,319.96928 4.32,0 0,-29.4 -4.32,0 0,12.16 -3.36,0 0,-12.16 -4.32,0 c 0,0.2 0,29.4 0,29.4 l 4.32,0 0,-12.8 3.36,0 0,12.8 z"
+             inkscape:connector-curvature="0" />
+          <path
+             id="path3233"
+             style="fill:#f5f2dc;font-family:League Gothic;-inkscape-font-specification:League Gothic;fill-opacity:1"
+             d="m -40.99375,319.96928 4.32,0 0,-29.4 -4.32,0 0,29.4 z"
+             inkscape:connector-curvature="0" />
+          <path
+             id="path3235"
+             style="fill:#f5f2dc;font-family:League Gothic;-inkscape-font-specification:League Gothic;fill-opacity:1"
+             d="m -22.331875,313.92928 0,-17.32 c 0,0 0.04,-6.36 -5.76,-6.36 -5.8,0 -5.76,6.36 -5.76,6.36 l 0,17.32 c 0,0 -0.04,6.36 5.76,6.36 5.8,0 5.76,-6.36 5.76,-6.36 z m -4.32,-17.32 0,17.32 c 0,0 0.08,2.16 -1.44,2.16 -1.52,0 -1.44,-2.16 -1.44,-2.16 l 0,-17.32 c 0,0 -0.08,-2.16 1.44,-2.16 1.52,0 1.44,2.16 1.44,2.16 z"
+             inkscape:connector-curvature="0" />
         </g>
       </g>
     </g>
     <flowRoot
        xml:space="preserve"
-       id="flowRoot2802-1"
-       style="font-size:18px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-align:center;line-height:110.00000238%;writing-mode:lr-tb;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;font-family:Bitstream Vera Sans;-inkscape-font-specification:Bitstream Vera Sans"
-       transform="matrix(1.7433323,0,0,1.2699132,-505.7749,20.09035)"><flowRegion
-         id="flowRegion2804-2"><rect
-           id="rect2806-9"
-           width="587.64703"
-           height="45.203621"
-           x="88.733032"
-           y="292.48868"
-           style="font-size:18px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-align:right;line-height:110.00000238%;writing-mode:lr-tb;text-anchor:middle;font-family:Bitstream Vera Sans;-inkscape-font-specification:Bitstream Vera Sans" /></flowRegion><flowPara
-         id="flowPara2818-3">Video sponsord by</flowPara></flowRoot>    <image
-       y="399.96448"
-       x="245.77768"
-       id="image3166"
-       xlink:href="file:///home/carl/src/veyepar/dj/scripts/bling/logos/microsoft-transparent.png"
-       height="124.76902"
-       width="308.44464" />
-    <image
-       sodipodi:absref="/home/carl/src/veyepar/dj/scripts/bling/logos/pyohio-med.png"
-       xlink:href="logos/pyohio-med.png"
-       width="267"
-       height="302"
-       id="image3231"
-       x="26.725964"
-       y="15.447394" />
-    <text
+       id="flowRoot3758"
+       style="fill:black;stroke:none;stroke-opacity:1;stroke-width:1px;stroke-linejoin:miter;stroke-linecap:butt;fill-opacity:1;font-family:Purisa;font-style:normal;font-weight:normal;font-size:40px;line-height:125%;letter-spacing:0px;word-spacing:0px;-inkscape-font-specification:Purisa;font-stretch:normal;font-variant:normal;text-anchor:end;text-align:end"><flowRegion
+         id="flowRegion3760"><rect
+           id="rect3762"
+           width="411.88046"
+           height="270.85617"
+           x="1.1192404"
+           y="342.28717" /></flowRegion><flowPara
+         id="flowPara3764"></flowPara></flowRoot>    <flowRoot
+       transform="translate(306.67187,271.80972)"
+       style="font-size:40px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-align:start;line-height:125%;letter-spacing:0px;word-spacing:0px;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;font-family:Purisa;-inkscape-font-specification:Purisa"
+       id="flowRoot3774"
        xml:space="preserve"
-       style="font-size:118.88734436px;font-weight:bold;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:none;font-family:league-gothic-1"
-       x="485.53452"
-       y="106.2201"
-       id="text3299"
-       sodipodi:linespacing="125%"
-       transform="scale(0.74231307,1.3471405)"><tspan
-         sodipodi:role="line"
-         id="tspan3301"
-         x="485.53452"
-         y="106.2201">PyOHIO</tspan></text>
+       inkscape:export-filename="/home/cats/Desktop/pyohio.png"
+       inkscape:export-xdpi="71.95591"
+       inkscape:export-ydpi="71.95591"><flowRegion
+         id="flowRegion3776"><rect
+           y="325.49857"
+           x="-160.05138"
+           height="236.15973"
+           width="562.97784"
+           id="rect3778"
+           style="text-align:start;text-anchor:start" /></flowRegion><flowPara
+         style="font-size:48px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-align:start;text-anchor:start;fill:#ffffff;font-family:League Gothic;-inkscape-font-specification:League Gothic"
+         id="flowPara3780">TITLE: Really long and interesting title goes here - I mean really long - it goes on and on and on and on and on some more and a little more even - perhaps than that</flowPara></flowRoot>    <flowRoot
+       transform="matrix(0.93559688,0,0,0.93559688,565.24221,207.01671)"
+       style="font-size:40px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-align:end;line-height:125%;letter-spacing:0px;word-spacing:0px;text-anchor:end;fill:#f5f2dc;fill-opacity:1;stroke:none;font-family:Purisa;-inkscape-font-specification:Purisa"
+       id="flowRoot3782"
+       xml:space="preserve"
+       inkscape:export-filename="/home/cats/Desktop/pyohio.png"
+       inkscape:export-xdpi="71.95591"
+       inkscape:export-ydpi="71.95591"><flowRegion
+         id="flowRegion3784"><rect
+           style="text-align:end;text-anchor:end;fill:#f5f2dc;fill-opacity:1"
+           y="325.49857"
+           x="-160.05138"
+           height="76.108337"
+           width="519.32751"
+           id="rect3786" /></flowRegion><flowPara
+         style="font-size:56px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-align:end;text-anchor:end;fill:#f5f2dc;fill-opacity:1;font-family:League Gothic;-inkscape-font-specification:League Gothic"
+         id="flowPara3788">BY: Very Long Author Name Here</flowPara></flowRoot>    <flowRoot
+       xml:space="preserve"
+       id="flowRoot3766"
+       style="font-size:40px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-align:start;line-height:125%;letter-spacing:0px;word-spacing:0px;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;font-family:Purisa;-inkscape-font-specification:Purisa"
+       transform="translate(861.81511,113.51987)"
+       inkscape:export-filename="/home/cats/Desktop/pyohio.png"
+       inkscape:export-xdpi="71.95591"
+       inkscape:export-ydpi="71.95591"><flowRegion
+         id="flowRegion3768"><rect
+           id="rect3770"
+           width="207.05943"
+           height="54.842777"
+           x="-160.05138"
+           y="325.49857"
+           style="text-align:start;text-anchor:start" /></flowRegion><flowPara
+         id="flowPara3772"
+         style="font-size:36px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-align:start;text-anchor:start;fill:#ffffff;font-family:League Gothic;-inkscape-font-specification:League Gothic">September 99,9999</flowPara></flowRoot>    <image
+       y="387.66003"
+       x="149.22198"
+       id="image4088"
+       xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAVgAAAGDCAYAAABulQisAAAABHNCSVQICAgIfAhkiAAAIABJREFU
+eJztvX90VPd95/1GCNnSeIRsGTlYxh5NUsH0GcWiTRBhk2OhUXdz2mgY0daFpwXEY+9sQ4iBzck5
+QH4AaQze5mQRMbRbbVoETpOm24MGudvNcyrh8SZxkJIexmudjqw60sQwyIgojDQeCcuKvH/ce8Wd
+O/f33Dv3ztzP6xwOur+/SMxb3/v+fn6s+OCDD0A4l/ZAwOohWMrA4GBe1zv9+1fs8H/+7YFADYDT
+AC4MDA5Gjbh/uRE3IQiCKFbaA4FmAK0A9gBoBnDBqHuTwBIE4VS62gOB0wBqzHoACSxBEE6hBsxM
+tRnANvZvUyGBJQii1KkBcBDAAZg4WxWDBJYgiFJFr7A2A4gaMYAVFEXgbObSP7d6CASRN8FQuAuM
+KLYC8AB4kv1az4z1RH+k5zhvezm6AALhrXJ/WPZGNIMlCKJoCYbCNQD6wIhpAoy4GkXe0QUksARB
+FCXBULgZzOt/K7vLY8R993b9QTOAOzDAryWBJQiiaAiGwh7ciwLoMuKeLlcVmvyNaGhYh5aWZngb
+1m0z4r4ACSxBEEUCawdcg0GRAC5XFYIdAQQ7AnC5qoy4ZQ4ksARB2BpWWA0Ls8pDWDVHF5DAEgRh
+S4KhcAjAU2CsAF3CGmjbgjdG3kSTfz3q6mrR0LAOTf5GvTPWrDGMN/qWowv8kwtRsQtIYAmCsBx2
+lhoC4616kGeWlctVhaNHPosm/3pMTU2jrq7WgFEyjDf6VEcXkMASBGEZRr/+A4C3YR06OgJo8q8H
+AMPEdf5HP26e/P+e1RRdQAJLEETBYaMBDiCP138+dXW18LJRAIG2LfneTpS712KaowtIYAmCKBjB
+ULgVjLCGjLqny1WFM6e/YlokQD6QwBIEURCCofBpMHaAIRQizEolktEFJLAEQZgKawf0waDygJtb
+muH3NyLQtqWgwlrmdksdkrQ4SGAJgjAFNswqr4wrl6sKm1ua0dLSvOyzWkWFb4Pma0hgCYIwFNZn
+PY08Zqw2ev3PCxJYgiAMIxgKHwdwTO/1dXW1CHYECv76bxYksARB5I2gbKBmmvzr0dERwOYW07u4
+FBQSWIIg8oItdq27eeCzzzyNYEe7oWOyCySwBEFohlcnIASddVjr6mpx9Mg+SxeutHCfzyd1aLXU
+ARJYgiBUwwrraeRR3JqLCjAr48osyqolw7QkfQ0SWIIgFOHVDNC9gNXkX49nnnm6aGasRkACSxCE
+JGxblj3Is2bAzh0d2Lmjw6hhFQ0ksARBiBIMhV+BzqgADn7ZQCdCAksQRA7BUPgg8hTXQNsWPPvM
+0yURz8pRVu3G0mxa9fkksARBZMGKqy6vlasTsLllo6FFru3CfT4f5oeGhbulF7naAwFzR0S0qti3
+Gtk/pAsAes0ZTjb9kZ5CPIYoEoKh8HnoqB2wuaUZzz7zRyUpqiqgYi8a8SA3DKVVsP2EyDnNMKYq
++172XjED7kUQqtAjrlzNACcuYKmhWARWTrjkjj2p8zorSQA4D2YWqySwfQA6zR4QUfpoFVdvwzq0
+tX2iZGoGmEU+AuuBdLBxDeQr6YgJn10Fr9B4AKSgziJoBvOhUHMuQYiiVVyf//oXHBsVoJVyyJcV
+ay3cUAgezQCugRHbrbj3C6sGTOX0KHteAsxsNwayEwgdsHUEulSf39HuaHGt8G0QW+TCyNqKGv/k
+Qkq4vxzMB7fV/KERGuF+6V0T7D8GRlgTYH5uCTCB4CSwhCbYJILzqs/vaMfOHZ8xcUT2p8xdLXVI
+tG1MsXiwJYfYLMDvb8zadrkq0cBLK7xy5ScYvPIakG3PeHCvz9EMgFh/pCdi8HCJEoNNfVUtrgee
+6yq62gF2gARWA3V1tXik7uGsfUJRrKurzQlV8TasM2Qh4My3euFtWIfxietih5ebyQVD4d7+SM/e
+vB9IlDKqOw6QuOqnqAVWTrgaGtbB5arUfMwoMTSaqalpHHiuC1eu/ERKYJc5emRfF/v6t7U/0pPj
+CxHOhu060KXmXBLX/DBcYMVmeRzCV14hYsJnV8ErNHV1tXg3M8dZBLJ4G9Yh0LalefDKaxPBUHgv
+WQYE2yerFUwTQpq56qS8/lFt50sdePaZpyXF0MmriFbibViH7tNfwSN1tfjSl78Jl6tq+ZfSyMgY
+3hh5EwBwa+qXOPBcFyYmrteMT1zvC4bCUQBnSGidCfs20wcNYZCBti0kriKU19dLHdK2yNXQsI6E
+1IZwtTS7T38l59jU1DRuTf0STf71mJqaRlvbJzD+19cBZubSGgyFU2CiDV4F0Nsf6UkUatyENfAW
+s1SLq7dhHQ4812XamEoU0e9vUXuwRDb8BTamOyfT5yiTmcfExHVcHYrVgBVbAMeCoXAEwOtgQr0i
+5NeWFrwwLNWdBF2uKjxH4moYJLAlDr+Z3OCV13DmW738wyH2DwCcDobCh/ojPVknEMUJryKWpuzI
+Zx3WccBsyqweAFE4Am1b0H36K1KLhjUAzgdD4fPsa2VesLMnwgLY1FfNXV537ugg39VgSGAdhrdh
+Hb7dc1Ku/3wX8sjsC4bCHrYS/jV25ZooIFrrCjT512Pnjg50n/4KVcRSQWXLJqlDT4jtJIF1IEwb
+j314/utfkBLaPXk+opX9+zTNZAuHnopYR498Fjt3dJAtkD8esZ3kwTqYJv96NPnXI5OZw/jEdYyM
+jGHwymuYmpoOBUPha9CXqFADZtHMAyZspRVUJ8F0tIort5hFMebmQgJLwOWqWhbbnTs6cHUohomJ
+683pdOb1r3z1v/7Jn33tP/9Qw+0SYEQ2BaY2woFgKBztj/TEgqGwB0CKohWMg/XL+6DB1vE2rMNz
+z3XRrLUAkMASOWxuaeasg8fn5uZf/eGPfnr2U5/8+HMqLw+BEdgTYKwGD+5V+zoAoCsYCsdwL3SI
+Ms10oicMi6uIRTPXwkAeLCFLVVXlik998uOfn0jc+OFn931lHzsLFYVd1DoNxhp4AozQ9oIR1Q8A
+HPQ2rONicWvYPwfMHH+pwtZxfQUaxPXAc10l1+XVCmSyuXLPNXEcRAnR4Hnskx7PYxuTN2+dC4bC
+J/ojPce5Y+xr6jEwH/YI7iUzAKwvWFdXiwPPdaHJvx5f+vI3l9N6wVgJJQH7C+YA7sUWp8B8P04Y
+lTXH+14fVDqXD9UVMI5Vj9VjMZkU7m4VO5cEllDNU0+1uH782r8ATBbYU2BSbleDEVHFmEsu9fqZ
+Z57Gf/tvf/vm6JvjRZ+Lzc7oW8HYIK2CwzVgvjddwVC4FwpCy4rnQQBPsbteBfM2EANjtYTACLim
++FYSV+sggSVUs7mlGd2nv4IvffmbyGTmWqF+YSW1erV77vbtX31ozZqHyh56cPXf/Pl/OfxGMBR+
+EjpaRFsNO1PlBNWj8rIu3POfo2AWABPsH+CeSPPv1wpmtqobElfjkWobIwYJLKEJb8M6dJ84gP/6
+4gXEf3FT7BSuoAy/h1jnN79xFAAmAKCmpvo6gAP9kZ7OYCh8Znj49Y8mfpGcefoPf/cXBflH6IT1
+PY9BvaiK0QwNvqlemFjnz1LBJhMof5Q8WMJEHvlIA07+2Rdw6c/P4qWRiQSYWdir4LWrYV93m9l9
+KdyzEbKiC/ojPYeuX5/8H01N6zvn5uavVVVVfoR9zF4w/qWlsCv1B1BEM20KwzKXCt8G1eeSwBK6
+WFntxh9+/Qjav/XijeqdO//HyjUP/xPuve6iP9KT4sKxrsX+9UMbm39TNLoAwMF169Zyl32M94gD
+sFhgeaX+iiYbLdC2hSIFLGJkbYXHP7mQ4O8jgSXyYnVX1ydXVFVuBHAOzOz0OHespqb6O3/w+5/+
+vfLylZhI3PhRg+cxDwTRBTJYFl3ALlwdw72Y3rxo8q9HR0dgOS05k5nD1aEYvvd3L2Nqajrf2wNg
+LIGdOz6TVT2NKDge8CYZAAkskSdl1W4AcLGbx8CsgL9669YvP/KX5772e7yZ1CfV3G/29vRU9Zra
+utnZd1dXVz9g+HiVYBewNFX/F6OurhZN/vVoa/tEjg/qclUtdwwYvPKaotC6XFUIdgSWG2yOjIxh
+ZGQM4xPX8UhdLVpamhHsCNCs1YaQwBJG0wqg9ZFHxPuy8clk5nD33Qxqqu7H3D8P4Op3/v7frk/e
+vrP1e71jDZ7HtgZDYU8huy7oaa3Chy+ows7CUnBCy9SCeBOZzDympqaXBdfvb0SgbUvW/Wjhyrbk
+tI0hgSUKAldQhmti+cbImzh56i+xNDuLr771UwDAvz306G9smp3GN//TF282fubTx3yV5d0vffH4
+N3Z94/iP830+K56tYMTzKTCvcr8A8CTuCWqrnnsH2rZg544O1aIqhrdhHS1KFQkrq6ulDuWULCSB
+JQxjIT6KlY/VY6XbvdwfbGRkjGtXA4B53fU2rMP4xHVkMnPYlJ5G5a8X8YM1j2NTagoPvX8Xvz1z
++9G+wR+fOPhYderfPbMz+MbO3VOuf/npfexj9nrH4qoXv9hX/vPIL7QqB2/DOnR0BCjG1IHIRBHk
+LIaSwBKGsBAfxY1tncvb332U8Qvfcq3Gr1bdv7yfP5OtTEyg881xvOVajYfefw+VS4sYrnkEm2Zu
+4alfJYF/Rc2Kzz2L/+evzj1yc9duLMRHAQ3RBcFQ+DQ0ppSqgSv1RzNOQgkSWMIQhJktnbfGAWB5
+dvqDNffenv7z53fj45t/CwAw9LUX8ND3v4+PZGYAAJtSt7Luc3PXbjxy7iwefekibu7ajYmJ6x86
+GArXyJU81FNlSg11dbXYuaMDm1uaaUGJUAUJLKGaxWRyuZLQ0mwamYEBlNfXY/rkKW52uUzlrxeX
+v/707bfxkbkZvFW1GvUf9iyLKwC0fPUwJv8tjvmhYazu2o2KDRtwn8+HCt8GLM2m8V48jrvDP8Xk
+qz/C439xFm998csbMIeJYCh8Akzr8WWhNTMpoMm/HkePfJaEldAECSyhmnf27cdCfBSVLZvw/o0k
+Vj1Wj+o9u7GyuhqVLZvwXjyOpdm06LUfyczgt/9wGx7cvz/n2CPnziIzMIDKlk1ZpeDKqt2obNmE
+f0m/h/fKVuL2X7+ET37j6/jOibM1U1PTp8G0pImyp3tgsM/KwbVWIXEltEICS6jmsct9mB8axmIy
+uSyGi8kkytxu1H7pCN6Lj+LWvmwBdW/vxJoXTsret6zaDff2Tsnjn2z/FABgyr8e333pH/Anf/QZ
+/MN3L+Pt6RSQR4NGgBFPv389XK5K+P2NyyFSDQ3r4HJVAqCwKCKXsmq32GQiJ7yPBJbQhLCr5vzQ
+MNa8cArzw8NwtQfg3t6J9KU+AMDqrt2oPXrEsGfX1dVi9xf+E5I/T+DEH/8uXp+5i+4Ll3Tdq8m/
+Hgee68ortIpwLvf5fGIVtSiKgDAWbua5in21X/PCSdy/6ePLPqoZ1H/Yg8W6WrS53ah95GG8cO47
+yGTmVF//7DNPU0opURBsJbBqaywSyqysrjZN4MTgP0vudd8oyt1uAMCTWz6Gv/nobyLyj4Pof3lQ
+VmipyhRRaGwlsJO79lg9hJKmvL4eqx6rX/66vL4eZW43KnwbsOqxek29huxE5QNV2LmjA8GOAL73
+d/+IwSuvZQktJQUQVmErgSXMZTGZFOsllEWFjwmTKq+vx/2bPp7judoZl6sKzz7zNJ595unlnl+P
+1D1MPithGSSwRBYL8dGcmNYK3wZUtmxCVSBQNIJLK/+EmUi97Y2srajxTy4sx2aTwBKKcKI703uR
+iU3dtAlV7QG42tu5coUE4Shk7LSsiloksIQmmAyuQWQGBjFdfQqu9nY80BkqmpktQRSSYhHYqNUD
+KCG4Xll5szSbRvpSH9KX+lBeX48HP/+5gkQQEESxUBQC6x2Lb7V6DKXMeKPPg3tpptzXq8EIMf+Y
+JIvJJG4fPoo7L56De3snVu/ZTfYB4XiKQmAJc/GOxRMQ9BISMt7o49pNe8AUrG4VO28xmcSdF88i
+famPZrSE4yGBJVThHYvHAMT4+1jRbQWwDQLB5Wa0MxcuovboEfJoiZKivP5RqUMe/kaZ6SMhShbv
+WDzmHYt3sxbOgwA6wbTjXg5TWYiPYnLXHtw+fFSy0hZBFBsyUQQe/gYJLGEI3rF4yjsWj3jH4nsB
+NADYC97iZPpSH95uC1A6NOEoSGAJw2HFtped2TaAmdViaTaNyV17MH3ylKXjI4hCQQJLmIp3LJ7g
+zWpPAEjN9F7E5K49ZBkQJQ8JLFEQWKE9DmAjgN75oWG83RbIScsliFKCBJYoKLwZ7cal2XT05q7d
+yAwMWj0sgtAEV5VOhCf4GySwhCWwEQhbl2bTe9/Zt3+G64JAEMUARREQRYF3LN67AvBcP/rVn5HI
+EqUGJRoQluMdi6cAfLzvY5/6bjuwk7K/iFKBZrCEbej82Q//3z8/+9KPUn2XrR4KQRgCCSxhK16v
+frjjT//m8tu3Lr9s9VAIIm9IYAlb0R/pSc2tLN/z3Lf7MPPmv1k9HIKQRKKpqIe/QQJL2I7+SE90
+fmV55E+/dg6ZyXesHg5BiLKyulpst4e/QQJL2JVDmcxc6kt//t+xkH7X6rEQhC5IYAlb0h/pSQA4
+Mz5xHX95/h+sHg5B6IIElrAz3QBSg1dew9WhmOLJBGE3SGAJ29If6UkBOAMAZ77Vi6mpaYtHRBD3
+uH+TchF5EljC7nQDSGUyczjzrV6rx0IQioysrVhuKkqZXAoEQ+FWSPSfMpmoYDvVH+lx3Htyf6Qn
+FQyFzwA49sbIm7g6FMPmFkOa4hKEWdRwX5DAKtMK4JgFz815ZjAU5r6MgmlS+DqAqAOEtxvs9+Pb
+f/19NPkb4XJVWTwkglCGLILipBVAF4DTAK4FQ+E7wVD4fDAUDlk6KpNgvdheAJiamkb/y1TekLAe
+mcaHy5DAlgY1YAS3LxgKTwRD4ePBULhG4Zpi4wL3Rf/Lg8hk5qwcC0HIlSxchgS29PCAeZ2eCIbC
+XdYOxTj6Iz1RMLYIMpk5msUSdqaV+4IEtnSpAXA+GAq/UkKz2Qj3Bc1iiWKAFrl00uRfD7+/seDP
+HRkZy9rOZOYwPnFd7pJWMLPZrSWwGHYBwEHg3ix2544Oi4dEENKQwOrE72+03Yf7jZE3MTU1jYmJ
+GxgZeZMvvDUAXil2ke2P9MSCoXAKbBgMCSxhJZUtyokGJLAlRJN/fdZ2JjOHq0MxDA3FcHUoVhIi
+C8Ym6AKYf9/gldcQaNti7YgIIpvlxofkwZYwLlcVAm1bcPTIPny75xR27uiocT/gulzknuyr/I0r
+V35i1TgIQgoP9wUJrEOoq6vFzh0d6Pmr5x///e2fLuYl+Ch/g7NFCMKOkMA6DJerCnt2b/+tO3dm
+3wAvpa9YYMsYpvj7rg5ds2YwhOMpq3bLHy/QOAib8eCD1f4PPvggAaAYE/uzPGSyCQiruM/nkz1O
+AutgVqxYsRrAKyg+kc3yYccnrlNMLGEnWrkvSGCJGhSfyCaEO6ggN2FHSGAJAKjB0tJlFI8nmxDu
+ECZgEIQdIIElGMrKHn8/8YtiiS7Ima6+MfKmFeMgHI5E6+5lSGCJZVZ5nvit20e+9MZ4o8/WM1m2
+fGEWU1PT5MMSBafMLdq6GyNrK2oAElhCQO2Rw/6y1dWJ8Uaf3T3ZHJFVqMlAEIWkGSCBJQSUVbux
+evfu1QBesbnI5tgE5MMSdoMElshh9Z7dABtdYHORzYIyuohCo9TVgASWyKGs2g339k6AEdk+u3uy
+HCSwRKFR6mpAAkuIUtUe4L70ADhv3UjUQx4sYSPIgyWkcbUH+HnWofFGn+0bKlIUAWEjagCqB0vI
+4GpvR/pSH7d5frzRF/WOxXNW762gP9KzVeLQHRRPwgRR4tAMlpCkYkNWEHUN2HYtNodyZomCsbJa
+PA6WgwSWkEQkS+WAFeMgCLsik8n1BEACS8gg0nOoZrzR12XBUAii2PAAJLCEdrZZPQCCKBZIYAlZ
+RGaxoWKJiyUIq6EoAkIPIQC9Vg9CAtHogvFGn2HRBWXVbnh+NmzErWzBYjKJt7e2F/y5rvYAHvmL
+swV/biGhGSyhhyetHoAODIsuWJpNIzNQLJUdlcn8szX/Fl4yS1Ejkc1F1bQI3RRNfQKzmCshgb07
+bM1s3NVe+FmzGax6TFRgKZOL0E2r1QOwmszAgNVDMASrZuOCTMGShQSWkOW9eNzqIdiSUrEJrPpF
+USr2gBIksIQsS7Np0f3jjb7Wwo7Eflj1am0kd4d/aslzS8UeUIKiCAhJFuKjVg/BMLxjcanaBaoJ
+hsLNAK5x23WJWXw735tajMIMNuEdizdovWcwFG4F06lYlM0tzTjqAHsAoBksIQPZA9n0R3pi4HW0
+nZqaLuoSiZmBQck3FJaIzlvLJqO0tJTWGqlUTdiRtRUeElhCEqteH21OluhcufITq8aRNyosjld1
+3lq2tOVmhwgsABJYQpr5oeL3GE3gAn/j6tA1qfNsj0L8a8o7Ftc8g2VtFI/U8c0tzXC5qrTetmgh
+gSVEWYiPYjGZlDvFkWUBS8UmUPHz1WsP7JE7WGr2gBIksIQoMxcuyh63S+Ftiyh6m0BFiBnZAwZA
+AkvkwMR4yq4uO3L2yiPLJhgZedOqcehGRfyr4fZAk3+9o+wBgASWEGHmwkWl1WVHC6zQJhifuF5U
+HW0Xk0mlELyIzjcUBXugGEtYKCNTdJsWuYhslmbTmLlwQek0va+PpUSUv1FMi10qiruYZA9s1Hlb
+e1PmlozpJYElsrl9+IjS7BUQiItDuczfKCYfVkV4luH2gLdhHerqarXe1vZkBgYxffKU5HESWGKZ
+zMCgmsWPmHcsnijAcGxNf6QnAmD5NbpYbAIVNRT0/nxl7YG2tk/ouKW9mem9iFv79svaLZQqSwBg
+wnZuHz6i5tQzZo+liIgA6OI2rg5dQ7DD3jn2Kha3LiudIEHJ2gOZgUG8e6kPZdXVqGoPYPFGEum+
+PlWp5CSwBJZm05hSZw2koD8+shS5DJ7AXrnyE9sLrIrsPLIHeEzu2pOVcJO+1KfperIIHM7SbBo3
+d+1WW9jljMPjX7MoRptARXEXPREirXIHi9UemB8azjeb8UmawSoTFdv5+LpHWwE8VdCRGMxCfBTv
+7NuvlNHDkQLQbfKQipEsm+CNkTcRaNti3WhkMLG4i6z/Wqz2QOrsuXxvUUMCq0B/pCcKcZE9jiIW
+2PSlPkyfPKXGFuDYS7NXUV4FT2CHhmK2FVgVbW40h2cFQ2EPZFoIFas9kL7Ul+/sNQLgBAmsw1hM
+JjH9/Cmt1fgjegp/OIQIgPPcxtWhGDKZOVtmLCkIhq7iLlBY3CpWe6Csujqfy7v9kwuHAPJgHcPS
+bBp3XjyHG9s6tYprDMBek4ZV9PRHenIW/q4O2S/RzariLsVqD6hsKR4B0Anm8xEBY6Ft5MQVoCiC
+kiczMIi5gUHNq58sKVhoDQRD4eP9kZ7jVjxbI5fBm8nZ0SZI9yn+/MkeEMCJ7K19+8UOb/WOxaNV
+7g9z271iJ9EMtsSYHxpeDoBOfGwTbu3bn4+4btW5qpw3bNuRY+yH2O7kzGAzmTmrxiKKCj/RcHvA
+71+v45b2wtUewOqu3cLdUe9YPKrmeprB6icqtjPzv37QuvDWzwuy+LUQj2MpzSxSvRePa1mwUiIG
+oNPijK1j7N9dYBYUbUt/pCcVDIUj4AnOVRvNYq0q7lKs/quQMneOH3tC7bUksPqJQkRkbx04dBxF
+HF0A5lXnkJURA8FQOIR7sZV7YHOBZcmyCUZGxmwjsCqKu2jO3lKyB+rqauFtWKf1trakvP5R/mav
+2tkrQBYBcY8EmFmrpeFYwVC4BsBp3i4Pmylkd2y70DU3qCiwUR23LdnUWCHu7Z38vls1Wq4lgSVS
+YF55NtokFOsYctMuD1gwDk2w0QTLqprJzNlCZJdm00r+KxV3UcGDn/8c92VovNGnelGDBNa5RMBE
+CDzoHYsft0MSAbuwdVDkkHC2dNz0wegjq5DukA0EVkVxF8Xiv0KcZA9wuLd3wr29k9tULbIksM4h
+CiZOrxPAg96xeKd3LN5r6Yh4sNbAeYnDNawvCzDerNgs1w7YziZQkb0V1XHbVrmDpWQP8FnzwklU
+tmziNkPjjT6xyUAWtMhlPFGrBwDmVZWbkcbsMDtVwWnIi+YeMAJm2+iC/khPIhgKx8DO7jibwMpG
+f/PyxbX1FnfZJnew1OwBGRT9WBJYg2FXGKMWD6OoCIbCXeDl80sQmro9/cd1a2pb2W27RhdcAO/1
+echCgTWjuAv7piG5wFWK9gAfgZ/9hNL5ZBEQlsJGCEhZA8u4XFVwP+DiV/PyQMYHtBDb2AQq7AE9
+xbUdEz0gRCTFvGtkbYVH7hoSWMIyWHF9Rc25O3d8BpWV9z8s2G276IL+SE8CgmiC8YnrloxFRXGX
+qI7bOtYekEjWOCa2k4MElrAE3qKWoo/V5F8v1SkgazY13ug7bsjg8sfyhohmFHdxuj0gQdfI2oou
+qYMksETBYT+or0DFK77LVYUDz3VJHV7+wI83+loBHBtv9HkMGWR+CGyCwrf0VlHcxXB7oKkEag/o
+5PzI2opWsQMksERB0SKuAPDsM08rVWTiAt750QWW0h/piYHJjAMATE1NF9wmUJEeG9VxW1l7oMXC
+aIlCoCKmOAcSWKJgaBXXQNsWNfn8oRuf2fbHyK5dYAeyZrGFtAkWk0lFe0Br6J6SPeByVVkajmY2
+80PDsgVz/JMLUbH9JLBEQeAtaKn6FHob1slZA1nc/9u/lRVdMN7os8MnPStDqpA2gRnFXaAYPWCH
+b7llSPrZJLCE6bApsJrE9fmvf0H1/at3/JHtogustAlU+K9RHbd1tD1wn8/HT5UV8rrUARJYwlSC
+ofBBMOKqqgqRy1WF557r0tTTqsK3gV/tCFCYbRWQrJlNIWoTLM2mlWq/ai7u4nR7AADKqt1Y88JJ
+VPg2aLvOpPEQDicYCtcEQ+E+ZJcelMXlqsLzX/+CrlAfweyiZrzRZwf+hbfpAAAgAElEQVSRzXoV
+L4TAmlHcBYq1B0pbXPloLWpPAksYDmsJTEDDTDIfcQUA9/acR1m+2MW2fF9eTBqfuI6pqWlTn6ki
+e0tPSUpH2wN8JBYPyYMlzIedtZ6HBksAyF9cAaC8vl74+hYab/RpKo5sEgWNiVXoGJzQWfvV0fYA
+H141LY6of3JB8tWEBJYwBNZrnYDGOFRuQcuIDKDVe3Ka09nOJjAzXEtFO3Y92VshyPyydJK4AhB6
+/YqQwBJ5EQyFu4Kh8AQYr1XTjLHJv94wcQUAV3tOOq0dogkiKJBNoMIe0OO/kj3A44HOnN/ZzZQq
+SxgOT1jPQ0fx62BHO57/+hc0RQsoUVbtFi52NTspdVZhgSuls/Yr2QM87vP5hLtqwKTKin4jqB4s
+oRq2VUgXmAUkj557cLUFzPpgVrUHkL6UFQfaBevrxl4GzzoZGnpdqniNbhbio2bUfpW1B5r8jVpv
+WfSUVbulDolmxpHAErLwYiC3IU9Ps8m/HkePfNbQWasQV3sAZdVuvthYXpi7P9ITCYbCKbBi9cbI
+m8hk5gz9PphU3IXsAQFSJSD9kwsJsf0ksEQObFprK4CnYMBCkctVhWefeVpNXQFDcG/vxEzvRW7T
+M97oa9b5emwkUfC+l1eHYoZ+P5TSY3V2DKb0WAF3h38qun9kbUWrWD0CEliHw85QOUF9kv3bsPCm
+YEc7du74jKmzViHuziyBBZjFrr0FG4A4l8ETrCEDBVZNcRet91QTPVDIn6lduCvd48wjtpME1gGw
+gf8A85/AA6aXkAeMsJoSKxpo24KdOzqUSg2aApc6yxOdEKwX2Ah4rXGuDsUMswlMKu5C9oCApdk0
+3ovHpQ7vAdAr3EkCqwArTq0WD0PIUwrHPbCorbWVwspn9Z7dmD55itusGW/0dVnZprw/0pMKhsIR
+mGATqPBfyR4wgDtnz8otJFIUgU5aodB3x+nU1dUu1261Wlg5XL8T4AsswMzIeq0ZzTKG2wSLyaSa
+4i5aa7+2guyBLNKX+oS2kxDR7xcJLKELLgaypaXZlrOZ8vp6VLZs4q/6hsYbfTVaxcZgDLcJFBob
+ApRckDd3XjyHOy+eVTotKraTBJZQjbdhHfz+9fD7G20pqkIe6AwJBagLQLf42eYjZhO8MTKW1/fS
+pOIuZA/wmLmg6nfUq2I7SWAJUVyuKlZQG9HQsA5N/saiey10tbfjNo7yd+2BhQLL8ioENoFewVqa
+TRte3IUN0fNIHXeaPZAZGFRbojAqtpME1sFwXUDr6mqz/ngb1pXEh4hLneVldjWPN/o8OitKGUUE
+vBq5V4diugsmzEuHDPGfpRXZMo9OswdUvCEATBaXaJw1CaxOmthXZTuhNJ5H6h62zSJUoRBJnT0A
+4JBFw0F/pCcRDIVjYFedM5k5XNU5izWpuAvZAzxUdpI94Z9coFRZI/H7G7FzR4fVwyAUcLUHxGJi
+LRNYlgvghfXotQkUPvwJrdlrSvZAk399SbzZqGV+aFiNPdDrn1yQtJ2omhZR8rh+J8Df9Iw3+lot
+GgqHoLqW9ixeFR/+qOabKtoDT+q4ZfHybp+iw3LCP7kgm8BCAkuUPO7OnG6glraT6Y/0JMDz7Dib
+QAtzg1a05t6o45bFyfzQsNBaEkNxwZQElih5KnwbctrJWDUWHln+6MjImKaLFdJjU1qLuyjZA96G
+dY7y7299br/SKRE1MdUksIQjEMxia8YbfV0WDYVDdxHuhfioUnGXqI7xyM7q29o+oeOWxYsK71XV
+GwIJLOEIBD4soJCtZDasTZDgtqempjE+cV3VtSqyt8geMB9VbwgksIQjKK+vh6s9S2RDNmgnk/Uh
+VdsQ0ejiLmQPZKNQ2wEAompTrklgCcdQ1Z4zi7Xai83yYdXYBCqKu6j+8PNolTvoNHvg17OzSqeo
+ji8mgSUcg6u9XdhTyepoghgENsE779yekbvGJHtA9vtA9kAWUS1lL0lgCcdQVu0WtvZuHm/0WZ2a
+lPU6P/rmz1+RO9no4i5sI0vJ74HT7AFA0SLIifmTgwSWcBQiNoGls1gIXjenp1PflDpRRXGXmI46
+C7I2idPsAQBYvCkdoaHVfiGBJRwFlzrLw1IfVmATxH5/+6d/xNvOQkVefFTHEMge4LGYTKpJMFAN
+CSzhOERSZ61e7OJe6y8LtrOQ6mjKQ1NxF7IHcpl+/pRcDKzmnGYSWMJxiKTOWhoTi3vFmjlhFRVK
+o4u7QGH27mfLWToJhRKQmrthkMASjkMsdXa80WdKd1019Ed6IgBirF0AMDOlBP+c+R+/NlPo4i5O
+9F9VFtdWDQks4UiEqbOwPiZWWJUpyyb49S9/KRtdAI3hWUr2AFd43UmoEFeyCAhCDe7t9rIJeLNX
+jiybYPHWlGR0AXQUdwGlxubwXjyudMovtN6TBJZwJExMrO1SZ/lkRRfUhJ+VjC6ACa1hnGgPKJCA
+jrbvJLCEY7Fh6qwQVdEFkOhoKgXZA7o4pKflOwks4Vjc2zttlTorgqroAmifwbbKHXSiPaCCqJ6L
+SGAJR2PD1Fk+ETBWQQwA2DCshPAcHTMrWb+Z7IFc9MxeARJYwuE80JnjCthtFisbXQDt9oBsxIST
+7YGV1dVSh3SJK0ACSzicypZNwtTZLouGIoVsdAG02wMUPSCBIDaaj/aulCwksITjEaTO1tggdVYS
+gU2gp7gL2QMSKBTS0QUJLOF4Vu/ZLdxldeqsEsLoAlWQPSBNZmAQtw8fMfy+JLCE4ymvrxe+HnZZ
+mTqrAmF0gVpkZ+ZNDqw9wDE3MGh4mixAAksQAEQLwNjZJoiAsQe0eoOyM/OWFjsFUBSWJeU2Mbog
+gSUIiKbO2i2aQIgwukAWJXvA5arCZgcLrEjSCR/dbzMksAQB0dTZVpulzmZhdGlCJ4srAGEkiRDd
+3xwSWIJgeSB3Fmtbm0AHZA8ImOm9uNx/690+WTtbT60HAEC53gsJotRwtQdQVu3mL3YcANBt4ZAM
+geyBXNKX+jB98pSaUyPQaMfwoRksQfAQpM56bJY6q5dWuYNOE1eASTAR1KGQ4rLeNFmABJYgshCJ
+ibX7YpcayB4QUF5fj9qjquJedYsrQAJLEFlU+DbYPXVWD2QPiODe3qm0uAXkmXRCAksQAgQhW7ZO
+nVUiGAqHIBNm5FRx5ahs2aR0iief+5PAEoQA93bbV9jSAtkDMki0ienGvQIvmlqhC6EoAoIQwKXO
+ciE8YLvO5rPYYSFkD4iwNJvG9MlT/J8xR693LH7IqOfQDJYgRBBZ7Co6m0DJHmjyNxZwNPbi5q7d
+SF/qEzvUamQdChJYghBBEK4FMDGxxQbZAxKIzFw5PABOG/UcEliCEEEkdbbZzqmzElB6rAQu+doD
+XUb9rElgCUICkdTZLguGoQs10QMuV1UBR2QvKnw+pVNajXgOCSxBSMClzvIopmgCsgckWJpNIzMw
+oHSa7jYxfEhgCUKGIk6dJXtAAonoAY4UgL06qpWJQgJLEDKIRBPYfrErGAq3guwBUWZ6L0pFD3Bs
+9Y7Fe416HgksQcggkjpbDOFaZA+IsBAfVaygZdTMlYMEliAUEMxiiyF1luwBEd7Zt1/xHKN/tiSw
+BKGAoK03YOPFrmAo3AyZ/Hmn2gML8VEsJpNqTjX0tw8JLEEoUF5fLywKErJx11lZ8XeqPVDh26Cm
+sEsKeXQvEIMEliBU8EBnzpujXW0CsgckWPPCSaXyhIfIgyUICyiG1Fkle6DJv96R9gBHeX09PvQX
+Z6U6GXQbGT3AQQJLECooq3YL68TaMXVWwR54slDjsC0Vvg14/MqgcHfMyApafEhgCUIlVbn563ab
+xSrYAxsLNQ5bIzKDzcmJNuxZZt2YIEoNkdRZ2/iwSvaAt2Ed6upqCzcgG3P78FH+Zsw7Fk+Y9SwS
+WILQgMAm8Iw3+lotGooQWXugre0ThRqHrbl9+Kgwk6vZzJ8hCSxBaMDdmfM2aZeYWLIHFMgMDEql
+yZ43y08ngSUIDdgxdZbsAXXMDeQsbnF4APSZEdtMAksQGhFJne2yaCgcrXIHyR5gUChR2Axgwuhn
+ksAShEZEUmdli6sUAFmbguwBpgbs0mxa6TSawRKE1ZTX1wtbjliWOhsMhT2QyZ8ne4BBIrlAyF7D
+n2v0DQnCCYjExHZZMAxAwQMme4BBpsA2x17K5CIIm+Bqb7dLOxmyB1Rw58WzcocjZogrQAJLELpg
+us5m1ScoeOos2QPKLCaTmNy1BxnpCAIAuGzW88vNurGRsC0wrOIJC59N2Jiq9oAwrvIAAFNy2iWQ
+tQf8/vWFGoetmB8axuyFi1hKp/FePK5mccvQEoV8ikJgAbxi9QAIQoirPYDy+np+IecQCiuwlL0l
+YPrkKcz0XtRySco7Fk+ZNR6yCAgiDwQhW55CtZNRsgfq6mrhbVhXiKHYhtuHj2oVV8CE0Cw+JLAE
+kQciqbOFioml1Fget/btV+oWK4WhBbaFkMASRB5U+DagwreBv6tQMbFkD7DcPnxUaRFLjhNGjkUI
+CSxB5IlgFlsDk+sTkD1wjzsvntM7c00A2Oodi5u2wAXYbJFLqilZ0xP2Ww11evgLcQ/X7wQwffIU
+f9c2AL0mPpLsAQAzvReV4luFRAGcAdPcMGbm4haHrQR27UsXRPc/X+BxEIQWuNRZ3mtqaLzR5zGx
+kPNTcgedYA8sxEeFv9SUOOQdi3ebNR4pyCIgCAMQSZ01xSYIhsKyFoRT7AGNM9e9VogrQAJLEIZQ
+wNRZx9sDGhe1Os1Kg1UDCSxBGIBE6qzkQlQeyIaBlbo9INLyRY69Zi9iKUECSxAG8UBnzuTS0Fms
+k+2BxWRSa6zrCStnrhwksARhEJUtm8xuJ+NIe2AxmcSNbZ1abIFu71j8uIlDUg0JLEEYiMmps7L2
+gN/faOCj7MOdF8+pKdjCEfOOxQtZD0IWEliCMBBBvy7AoNRZJXvA5arC5hYzLF9rWZpNa00kMDUz
+SysksARhIOX19Tk2gUGpswr2QOmJKwCtsa6WL2oJIYElCANZmk3zyxcCxqXOys6EW0pQYHVEDPSa
+OBxd2CqTiyCKHYnW0HuQR+qsk+yBpdk0Zi5cRPpSn/AXlRQJMFlatpq5cpDAEoSBzImvdLfmmTrr
+CHtgIT6Km7t2a1nQSgDYWIiaAnohi4AgDGJpNi0XSpSPTXBA7mCp2APTJ09pEVeAiXW1rbgCJLAE
+YRgS9gCHrEhKoVSasFTsgZnei5gfGtZyScqOnqsQEliCMIiZC7LtSjw6u852yR0sdnHlqmJpjBYA
+Ctv7TDfkwRKEAcwPDWMhPip3SkqnByubbmuFPTA/NIy7wz+Fqz0g7OagiaXZtFbPlcOWEQNikMAS
+hAGkzp5TOkXzKjfbrt4jddwKe+DOi+eWSwXOXLiAR1+6qFtkMwMDWsQ1BaZYdq+JdXYNhwSWIPJk
+fmhYjX94WcetZWevhRbXhfhoVh1Wbgb6+JVBYanGHJZm05g+eUqrqHLEwLR3sfWClhjkwRJEHizN
+pnH78FGl01Ja4zTZ2NcuuXM6OnKKfJsGJ6Zi+xW8ZyzER3FjWyfSl/r0iCvAxLkWnbgCJLAEkRfT
+J0+pCYjXEwTfJXewkKUJlbzSmQsXJL8HnLiqTBoQo9s7Fo/qvdhqSGAJQifpS31qUznP6Li9bFhX
+oG2LjltqZ35oGDe2dcou4C3NpvHOvv05+xfio6L7VRIDM3MtimgBKciDJQgdzPReVBtaFPWOxWNa
+7h0MhUOQWdwCCiOw6Ut9auwPAIyY3j7ypZGHDh14eHHynQfm/vcPH9DYN4tPCkXquQohgSUIDXCL
+NVoq6+t4jOzstcm/3vS28dy/UwMn1px6/jgA/OKTT9UAeAUyCRIKREpBXAESWIJQTfpSn9Z0zqhW
+/5ANzWqVO6cQfbfunD2rtcj1cW7DOxZPjTf6tgKYAFNNTI4UmKSBkhFVPiSwRFEwPzSMyV17UF5f
+j1WPMfVWK3wbUOauRpnbvRyLueqxnHqseT93bnBQzwp4CsBeHY+Unb26XFUFswdUkgKwVbiTFdkz
+AI7JXBsD0/U1oXmARQIJLFFULCaTyyvSSrGnFb4NWFnNCbAPAFBe/6ikAC+l01iIj2IpPYuF+KjW
+3Hghh7QKB1t3QLYoTCHEdTGZVPvLRMkr7QYTy+sRORbzjsVLs4kYDxJYomThr3xraJhnBL06UznP
+K50QLEDsq0pxjYJJWU1IncDOYjsBXBMcigHo1Du+YoIEliCMpVtPaJEa73VzS7Ppi1sA8OvZWaVT
+er1jcVX2h3csHmNF9hiYGe+rdun4WghIYAnCGFJgbIFendfLeZUACpu5JQO3KKUaNovNlh0HzIYS
+DQgif3oBNOgV12Ao3AWF2WuTfz2a/Ov13N5obF/k2k7QDJYodqLesfhWttaqh93XDCY8aDXuxWLy
+jxvyXDAFXHrzERy25sBppfOMnL1mBgYxy9YPqPBtQMWGDVkLf+/2yU42ew0biAMggSVKAnaxJcFu
+RuXOHW/0cQJcg3sC/ASkBTgF4HX275jBufHHoBArWldXa1jlrFv79mct+GmMlEjQ7FUbJLCE4xCk
+rlrmDbILWweVzjvwXJchz1uIj+YbTUHiqhHyYAnCAlhrQDEsy0jvVUV0gBIksBohgSUIazgPFZ7w
+jh2fMX8khGmQwBJEgQmGwgehoo13oG2LoZEDedRkJXRCHixBFBC2FKFi1IDLVYVnn3nakGdmBgbx
+7qU+Nf5rBPdq1zYDeBLZs+wLhgzIQZDAEkSBCIbCzVDhuwLAzh2fgctVlfczF+KjuKWu6HWnoK1N
+NO+HE2QREEQhYMX1FSiX70OTfz2CHe2GPFdl1EBMa88wQh0ksARhMlrE1eWqMiwsK32pDyq7ClB0
+gEmQwBKEibCxrqrEFWBiXo0o6KKy2y1hMiSwBGESbLSAanENdrQblrFVVu1GWbVb7ekJQx5K5CBc
+5OJeFVT9hyAIIhdeEoFiKBbH5pZmw6IGONzbOzHTe1HulAiAC+S/mgd/BtsLoIH9o6kLJkEQDKwl
+cA0axNXbsM4w35WPu1O2pnXMOxYXRg4QBsPNYLuRXeNx630VFdcBPFD4IRFE8cG2ezkGoEvLdd6G
+dXj+618wJCRLCNenTILLhj+QyKEcjP8ibC2ceuKJ+hEAmws+IoIoIlg74CCYZoWarDUzxZWjwrch
+q3UOS6+TugpYSTkkOl/ed1/F3QKPhSCKBnbGegDMjFXzmkWTfz2OHvmsqeIKACurq4W7UmrbvRD5
+Q5lcBKESdrYaArANGjzWnPt0tBu+oCWFSL3XmvFGXw3VdS0MqgT2gw8+mF1c/PWqVavKK80eEEHY
+CXam2oo8RRW4l0RgVCiWEjLFtLvArLsQJqNGYHtXrFhxaNWqcoCJ6SvM/w6CKDCsmHrACOqTYP6v
+e4y4d5N/vWFJBGpYmk1j+uQpqcN7QAJbEJQEtjsYCi9HF/RHera+n0hcX+XxUHQBYQvecq1uPRgK
+X8O9GO4YgBne18JX4Vbe1/yeXa0wgbq6Wuzc0YFA2xYzbi9KZmAQtw8fwdJsWuoUmiQVCDmBTUAQ
+XRAMhVPn3rs5Uv/9723WkCUiyWIyiTJ3NZbSs1lN1whCI3zBaLVqEHxcrioEOwIIdgRMX8gCgLe3
+tmuq9zre6GsWtM4hTEBSYIOhsOhK4/s///ndm7t249GXLmpJxctC+Bu2vL4ej78yoOteBGEn6upq
+EewIINC2pSDCyrGU1twOhrI1C4CuKIKF+ChufW4/Hjl3VpPILsRHMXPhItKX+rL2LyaTSF/qg3u7
+bOYJQdgSl6sKm1ua0dLSXLAFLCEq0mKzMLgzLiGB7jCt+aFhJDt/f7bq3//OqqrWpyorWzaJnrc0
+m0b6Uh9mLlyUfYV5ty9CAksUDXV1tWjyr7dUVPnUHj2CMnc1Zi5ckPNeOaIFGBIBYEWgrU3TBd3/
++sNXwPhcvbiXXvtKZcum5pr9nwMntJyw3jl7Vs0PHGXVbnh+pqlHO+EwFuKjy51RF+KjWEqn8auK
++/D9Xy0gk5kHAIxPXEcmM2foc+vqavFI3cPw+xvR0LAO3oZ1BYsG0MpCfBQ3d+2W+8ylAGwl/9UY
+qtwflj2uV2BjB3/zU4cAoD/Sg/FGXw3YEK7y+nqUVbvF0vMU8Y7FNV9DEFLwxXZi4vqyCPO/5vD7
+G5e/drkq0dCwDgAMbTpYKBbio7ixTfRtMAJgLyUZGIeSwOqxCBIQRBd4x+Kp8UZfJ4Bri8lkDXQ2
+r1xMJimagDAMLyuSgL2FcjGZxPs3mA+NlNWmhQrfBlS2bOISDRq8Y/FE3jcldKFZYA/+5qdEowu8
+Y/HEeKNvKzQUGBby7v/8X2/U/MdnHseKFav1XE8QxUZmYDCrKWFlyyasfSn/5q1l7uXFZ5qtWoih
+HQ1YX6cT2n+oMQB7a8LPfhQrVjQDODE3N/+zb//13+PKZw/izovnVPm4BFFszAmaEs4PDedE2ehh
+Kb38eenK+2aEbjR7sEL6Iz05+8YbfR7cK4rRKnFpCsxC2RmpV5hgKPzBRzIz2P+L/4MK34a8Ym8J
+wm7IeKVwtQeWRbIqEMDqrt2a7p342Cb+pOQEgG7yXo1HyYM1pSeXdyye8I7Fu71j8a0AtiI7LCQF
+Jg+6wTsWP6TgD0WS97sAMP8Z75xV1SGTIGzPTO9FvMOzBoRkBgYxPzTMzGj7tM1oF+Kjwje+YwBe
+YRejiQJierlCNqA5ys5qazSGh1yeX1m+XMEofakPq/fspoUwoqiZPnlKU1LAQnxU0wIwF8kjEFmu
+dfhGLWMl8qNgXWXZWa3W2LsIgNivVt0PgIutpRZCRPHCxYer4Ver7sdbrtV4y7VadrYrpKzajQf3
+i57fPN7oa1V9IyJvbN22uz/SkwKw90cPrZ2fX8lMthfiFCtLFC8zFy6qWrB9w12Lr/3Gx3H2iY/i
+7BMf7V2Ij269ffio6LlLs2ncefFcVuz56i7JNz2yCQqIrQUWAPojPbErtY9t+YZ3I36w5nGM/0pz
+UQuCsA1qZ69vuJczxboBHPKOxaPpS329Yunmtw8fwZ0Xz+Lmrt1ZIiuRek4LXQXE9gILMCL7q1X3
+n/jBmidw6u79Vg+HIHQxPzSstqRgbLjmkY0ANvZHeg6xb3LwjsX3rqi4b0R48vvsPZdm07i5azcy
+A4NYTCaRGRCtUEcpsgWkmHpydYOpxO65OhSzRYENgtDCu32q1g+6AZzpj/QkRI61rlzzsJ+/Y2k2
+nTVrXZpNZyUuCIhRqFZhKYoZLLDsx14AgKEh+iVMFBcL8VE19sAhmdDFVgA5N5j74Q/f1TAMD4Vq
+FZaiEViWbgC4OhTD+MR1q8dCEKqZOnxE6RQu8UYMrphSjji+dy32RxqGUQMmJpYoEEUlsOwsNpbJ
+zOFb3+o1vCwdQZjBTO9FNdXlzsi8vtdAfHGqt/bLR/8JgGh9EPaaE8j2XQ+yMelEASgqgWVpBphS
+dF/68jetHgtBKMKrCyBHr8yxBIAHBed0g63H7B2L97LnCNnrHYsfB5NNyRfZLjUDIvKnGAU2wX0x
+PnEd3/u7ly0cCkEYQlRlScG9YDKxNoIRV/6sVuz6BMCUEwUjshF2H2XrFIhiiiLgSIDXq77/5UEE
+2rbYtsI8QahAS33CnBVeNjurVbA7xc+cZEWWejIVmGKcwWaRycxh8MprVg+DIPQSY1/xdcGKq1h4
+As1SbUAxCuyrwh39Lw+KnUcQxYDUApUivFZNYqFXJ0T2EQWmGAU2KtyRycxR2BZhWyQyqgCmRms+
+Qd2S0QXUJsYeFJ3A9kd6omB+62f9x+L3XyIIu6AQojWTz73ZCnWS0QWE9RSdwAJAf6SnF8xK6gmw
+Qjs1NW3lkAgih/SlPkyfPGX6c7xj8eXoAjYTjNJhbUIxRhEAANhc7eMAjgdD4dYPPvjgvwP4iKWD
+Iggw9QBuHz6CzEDh1gbytBoIkyhageXD2gY3QAJLWMzSbBpvtwWoSScBoEgtAglyogsIotDc+tx+
+EldimVIS2KjVAyCczWIyifmhYS2XUKxqiVNqApsTXUAQNiXfEC2iCCglgQWYcJWs6AKCKBTl9fVS
+bVqE9HrH4hRK5QBKTWABplbBcTDVh7beOfeXb2l8bSMI3ax54SQqfBukDqcAdLJhVYQDKIkoAhmi
+d8586waAj1S2bEL1nt1wtQdkL1hMJpH550HcHR7Ge/FRrHqsHlWBAFZ37S7MiImix9XeLpZckALQ
+QDGqzqLUBRZgogta54eGlxcgXO0BVPh8WSdxCxTCpnTc/pkLF1H7pSOKAk1Is5hM4v0bSdzn86Gs
+2m31cEyjvP5Rsd2dJK7OY8UHH3xg9RhMZWRtRSuYghiGUOHbgMqWTShzV6PCt4EEVyW3Dx9d7klV
+Vu3Goy9dlHuVLnre3trO/2Wd8E8uNFg5HsIaSl5gAWBkbUUXgNMQrzqUF6u7dqP2qGK/JUfDF1eO
+Ct8GPHZZsQlg0XLnxXO48+JZbpME1qGU4iJXDv7JhV6YFF0w03tRba97R7E0m0ZmYBCTu/aIdlNd
+iI+q6VNVKnjYX/KEw3CCBwsA8E8uJMDWLmBtg2YA25BbCV4zd148hzUvnMz3NkXNYjKJd/bt1ySa
+v56dNXFEtuP8yNqKmH9ygWJfHYQjZrBC/JMLUf/kQrd/cmEr7vUqUiIBphRcJ4AG9rpugKn36eT0
+yMVkEje2dWqekd4nWGgsJe4Oi4YGhgo9DsJaHDODlSGKe2m2IbBda3kk2OMJif1nFtKZsze2df6e
+e3snG6FQuos3Ykw/f0rzL5gK34YSjySoF9v9RKHHQViLIxa55BhZW5HX9d6xOABgvNHXDKD1bln5
+h+4PtP2u59TXm/IVEMbHHMDMBaZoc1m1G5WbNuHBz++3hYgvzaYxffKUqMeqhMMWufg0sHYV4QBI
+YA0SWCHzV4eilZtbntJ6Py7udm5gULae6NqXLqCyZZPW2xvC0kbro9IAAAZVSURBVGwad86eRfpS
+X17WyEP/+1XUfKjOwJHZh4X4KG5sE02bPeGfXDhe4OEQFuFID7YQVG5u6dZ6ze3DR/H21nbcPnxU
+sVjzrc/tL2hBZ475oWHc2NaJmd6LusR1fmU53nDX4uwTH8Xx//JXJozQHlT4NkjZBISDIA/WPKJa
+Tl6Ij2p61V6aTePWvv0or6/HqseYD3KZ240Knw/l9Y+ivL7e8Bnu0mxaT73TBJgsplgwFD4PoGv5
+yMR19L88gGBHu6HjtAur9+wuSMsYwr44XmD9kwtm3TqVmY7/zxUVFb+n5uR0nz4/cjGZzIrD5c9q
+y+vrseaFk4YJ7fzwsB5x3chLET0EZhFxeSFxZGSsZAVWwiePFngYhIWQRWAiKyoq/uT9t9/+s19P
+Tb2jdK4ZQfeLySQmd+3BrX3GVNmf025JZDXg64/0pMCEtyW4fXV1D+c9riLDY/UAiMJBAmsuqVWP
+P/7VlXV1awE8OPPSdw69e7k/Z8q8NJvWWgk/Bbb2rXcsvgJMacZOAKJB7JmBQdzclV81MI0WRgrA
+Xu9YPCe+mBXZTrAzOZerMq9x2Zm7wz8V2+0p8DAIC3F8FIGZzKV/nrNvvNF3ury+/iBXmUtDBlQC
+jChdFhMu3v1fgUR2mljkwUJ8FFOHj2BVfT2q9+wWtRMyA4OYfv6UmpTgFJh05F41laOCoXDr3q4/
+ONgZ+vfblM4tRgQFXzhi/smFjVaMhyg8JLAmIiGwIQBaDde93rF4r5oTxxt9NQDOQyRr6MHP78eD
+n//c8vZCfBQ3d+3Osg8qfBtwn8+H8vp6LMTjWnzXKDvOhJqTedQAuKPxGluQvtSHuYFBVLUHshYV
+VbTtplhYh0ACayISAqtVUGLesbjmGc94o8+De6+jNQCaV65Z8xuP/u3F4CqP5wE9tQNkyLeYdHZ0
+QRGQGRjErX379V7e7Z9coJYxDsDxUQSFxjsWT403+iJQn5d+QedzEshO7122Fd59+R9/d+oLX/wi
+DCh0wxLNs5h0TnSB3Zl+Pq/wq6L5dxL5QQJrIuONksVM9oLptLAHyh+2mMx99PJP7J8QmNljvnVy
+L+d5PRddcA1Fsgi0lHZUJTBCJxRFYA0pMJW4NoJtzggmKkDsvKiJ44iwz86HmFp/WIGs6AK7k2eW
+1qtGjYOwNySw1sOJ6F4wZRC5V/kE8hc/Rbxj8RjERS0G5heAnOhF2ONGEQPzb946/6MfX77z4jnM
+Dw0jfalPV0EZM8nTu+41aBiEzaFFLoczl/45xht9xwEc4+2OAdjK91XZamHNYF7hY8jfd5VFbDGw
+rNoNV3s7HugMWVboBmASON7eKpt91gvGNtkG5vvVyu5PAdjrn1xQU3+YKAFIYB0OK7A1YBpDNoNX
+O8DSgQEYb/RJRhdYWU0sfakPtw8flToc8U8uGDmrJ4oYsggIeMfiKTYUbKN3LN5gB3FlOQSJ7LR3
++6ybBC6MytoDFH5FLEMCSyxjI2EFwAg/BLULONKX+ixrmqjwXNNsE6L4IIElbA0rsqILbe8YVMTG
+YDxWD4CwDySwhO3xjsVj3rE416DyBPsnOn9z8rv/vO+QrdqmU9dYgg8tcjkcsXTeYiIYCh9/+P6K
+Y8cO/ymeaPYX5JkSRVwAIOGfXGgoyCCIooBmsESx0/vLuwv4/PFv4dnwEfzib//O1IctzablZsxR
+Ux9OFB0ksERR0x/pSYBJ0ohOTU2nXn7Z3D5lmYEBucOvm/pwouggi8DhFLtFIEbmB///tOvT/+Eh
+M+49uWuPXHH0rf7JhagZzyWKE5rBEiVH+dq1R4y839JsGpmBQSVxJYgcqJoWUXLc9+RH/x6Arp7g
+mYFBLM3Ooqy6GnMDg5gfGrZVlAJRXJDAEqUI17rmmNKJADNDTV/qw8yFi/mKaSKfi4nSgzxYh1OK
+HiyLB8CE3AnzQ8N4ty9iVKWulH9y4UEjbkSUDjSDJUqVBJjoAq6oeQ3nny4mk7g7/FOjSyBShSwi
+B5rBOpyRtRVWD6GQmNn7iyIIiBwoioBwEvm2thGSAtsVgsSVEIMsAsJJRPO4NgJGUGvACHUUTGps
+/qMiShYSWMJJaIouYM/vBXAGFCFA6IAsAsJp9Ko4JwpmgexBMAW0E+YNhyhlaAZLOI0EBNEFuGcd
+JMB0fO0t/LCIUuT/AlwJoQfL/wPaAAAAAElFTkSuQmCC
+"
+       height="168.75"
+       width="150" />
   </g>
 </svg>


### PR DESCRIPTION
Watch out for embedded http://pyohio.org/site_media/static/img/py-big.png file.  Microsoft logo has been replaced with SVG. Font is League Gothic, available at http://www.theleagueofmoveabletype.com/fonts/7-league-gothic
