### PR TITLE
Set YouTube license to CC-BY-SA

### DIFF
--- a/dj/lib/youtube_v3_uploader.py
+++ b/dj/lib/youtube_v3_uploader.py
@@ -155,6 +155,7 @@ def initialize_upload(youtube, filename, metadata):
               },
           'status':{
               'privacyStatus':metadata['privacyStatus'],
+              'license':metadata['license'],
               }
           }
 
@@ -289,9 +290,12 @@ class Uploader():
             part='status',
             body={
                 'id':video_id,
-                'status':dict(privacyStatus=privacyStatus),
-                }
-            ).execute()
+                'status': {
+                    'privacyStatus': privacyStatus,
+                    'license': 'creativeCommon',
+                },
+            },
+        ).execute()
 
         """
         >>> videos_update_response

--- a/dj/scripts/post_yt.py
+++ b/dj/scripts/post_yt.py
@@ -127,8 +127,7 @@ class post(process):
         meta['language'] = ep.language
         meta['language'] = "eng"
 
-        # if ep.license:
-        #    meta['license'] = str(ep.license)
+        meta['license'] = 'creativeCommon'
 
         # meta['rating'] = self.options.rating
 


### PR DESCRIPTION
And maintain it thorugh the flow. Updating a video's status requires
specifying the license too.

YouTube only has 2 licenses: "YouTube standard license" and CC-BY-SA, so
I think CC-BY-SA is a sensible thing to use for all videos.