### PR TITLE
pyconau2019: Fix Creative Commons licenses on YouTube uploader

### DIFF
--- a/dj/lib/youtube_v3_uploader.py
+++ b/dj/lib/youtube_v3_uploader.py
@@ -281,7 +281,6 @@ class Uploader():
                 'status': {
                     'privacyStatus': privacyStatus,
                     'embeddable': True,
-                    'license': 'youtube',
                     'publicStatsViewable': True,
                 },
             },
@@ -290,8 +289,8 @@ class Uploader():
         """
         >>> videos_update_response
         {u'status': {u'publicStatsViewable': False, u'privacyStatus':
-        u'public', u'uploadStatus': u'processed', u'license': u'youtube',
-        u'embeddable': False}, u'kind': u'youtube#video', u'etag':
+        u'public', u'uploadStatus': u'processed', u'embeddable': False},
+        u'kind': u'youtube#video', u'etag':
         u'"fpJ9onbY0Rl_LqYLG6rOCJ9h9N8/yzjxcIfiMnHpq7I5wbMY44afabU"', u'id':
         u'cUvNths_5RA'}
         """

--- a/dj/lib/youtube_v3_uploader.py
+++ b/dj/lib/youtube_v3_uploader.py
@@ -133,7 +133,7 @@ def initialize_upload(youtube, filename, metadata):
               },
           'status':{
               'privacyStatus':metadata['privacyStatus'],
-              # 'license':metadata['license'],
+              'license':metadata.get('license', 'youtube'),
               }
           }
 
@@ -281,7 +281,7 @@ class Uploader():
                 'status': {
                     'privacyStatus': privacyStatus,
                     'embeddable': True,
-                    'license': 'creativeCommon',
+                    'license': 'youtube',
                     'publicStatsViewable': True,
                 },
             },
@@ -429,7 +429,7 @@ def my_upload(args):
       'tags': ['goodtimes', ],
       'privacyStatus':'unlisted', # 'private',
       # 'latlon': (37.0,-122.0),
-      'license':'creativeCommon',
+      'license':'youtube',
     }
 
     u.oauth_file = args.oauth_file
@@ -456,7 +456,7 @@ def test_upload(args):
       'tags': ['test', 'tests', ],
       'privacyStatus':'unlisted', # 'private',
       # 'latlon': (37.0,-122.0),
-      'license':'creativeCommon',
+      'license':'youtube',
     }
 
     u.oauth_file = args.oauth_file

--- a/dj/scripts/post_yt.py
+++ b/dj/scripts/post_yt.py
@@ -101,8 +101,17 @@ class post(process):
         meta['language'] = ep.language
         meta['language'] = "eng"
 
-        if "CC" in ep.license:
+        # YouTube treats 'creativeCommon' == 'CC BY 3.0'
+        # Only use it when the license **exactly** matches that, even if for
+        # a different CC license.
+        # Reference: https://support.google.com/youtube/answer/2797468?hl=en
+        # Context: https://2019.pycon-au.org/news/video-licencing-changes/
+        if ep.license and (ep.license.upper().replace('-', ' ') in (
+                'CC BY', 'CC BY 3.0')):
             meta['license'] = 'creativeCommon'
+        else:
+            # We're not sure -- play it safe.
+            meta['license'] = 'youtube'
 
         # meta['rating'] = self.options.rating
 


### PR DESCRIPTION
[YouTube treats everything `license: creativeCommon` as CC-BY-3.0](https://support.google.com/youtube/answer/2797468?hl=en), even if it is under a more restrictive Creative Commons license.  The license attribute was previously escalated to YouTube, and it was explicitly declared that this is intended behaviour (as at 2012).

Incorrect annotation [causes problems with bad actors ripping off content, and limited recourse with YouTube](https://2019.pycon-au.org/news/video-licencing-changes/).

This changes Veyepar so that it treats only `CC BY` and `CC BY 3.0` as `license: creativeCommon`, and makes everything else `license: youtube`.  It also makes the default behaviour `license: youtube`.

Without this change, it means we need to incorrectly annotate videos to make YouTube honour the license.

This partially reverts #56, which erroneously indicated that YouTube treats this as `CC-BY-SA`.